### PR TITLE
Document package dependencies

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -13,6 +13,15 @@ The `happy-dev` micromamba environment has been successfully configured for hap.
 - **Testing Framework**: pytest 8.3.5
 - **RTG Tools**: Available at `/Users/nolson/hap.py-modern-claude4/hap.py/external/rtg-tools-3.12.1/rtg`
 
+## System Dependencies
+
+Before installing hap.py in this environment, ensure that common build tools and
+libraries are present. On Debian/Ubuntu systems these can be installed with:
+
+```bash
+sudo apt-get install -y build-essential python3-dev cmake zlib1g-dev libbz2-dev libboost-all-dev
+```
+
 ## Required Activation Command
 
 **ALWAYS run this before any development work:**

--- a/README.md
+++ b/README.md
@@ -367,6 +367,20 @@ pip install .[dev]      # For development tools (testing, linting)
 pip install .[cpp,dev]  # For both
 ```
 
+For an editable installation that includes both development and C++ extras, you
+can run:
+
+```bash
+pip install -e .[dev,cpp]
+```
+
+Before installing, ensure that basic build tools and headers are available. On
+Debian/Ubuntu systems the required packages can be installed with:
+
+```bash
+sudo apt-get install -y build-essential python3-dev cmake zlib1g-dev libbz2-dev libboost-all-dev
+```
+
 ### Building from Source (Advanced)
 
 If you need to build from source and `pip install .` does not meet your needs (e.g., you need to customize the C++ build process extensively or are working in an environment without pip):


### PR DESCRIPTION
## Summary
- mention build requirements in README install docs
- document system dependencies in ENVIRONMENT_SETUP

## Testing
- `pytest -m "not integration" -q` *(fails: Module attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841a741d584832cb0e95d5bea82c6f4