### PR TITLE
Add CLI wrappers and utility stubs

### DIFF
--- a/build/bin/hapcmp
+++ b/build/bin/hapcmp
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Wrapper script for hapcmp main module."""
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root / "src"))
+from hap_py.haplo.python_hapcmp import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/bin/hapenum
+++ b/build/bin/hapenum
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Placeholder wrapper for hapenum tool."""
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root / "src"))
+try:
+    from hap_py.utils.hapenum import main
+except Exception as exc:
+
+    def main(*args, _err=exc):
+        print(f"ERROR: hapenum not implemented: {_err}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/bin/multimerge
+++ b/build/bin/multimerge
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Placeholder wrapper for multimerge tool."""
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root / "src"))
+try:
+    from hap_py.utils.multimerge import main
+except Exception as exc:  # if module missing or fails
+
+    def main(*args, _err=exc):
+        print(f"ERROR: multimerge not implemented: {_err}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/bin/preprocess
+++ b/build/bin/preprocess
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Wrapper script for preprocess main module."""
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root / "src"))
+from hap_py.pre import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/bin/quantify
+++ b/build/bin/quantify
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Wrapper script for quantify (qfy.py) main module."""
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root / "src"))
+from hap_py.qfy import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/hap_py/utils/__init__.py
+++ b/src/hap_py/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility modules for hap.py wrappers."""
+
+__all__ = []

--- a/src/hap_py/utils/hapenum.py
+++ b/src/hap_py/utils/hapenum.py
@@ -1,0 +1,71 @@
+"""Simplified hapenum tool placeholder.
+
+This module sketches a Python replacement for the original C++ hapenum
+utility. It parses a VCF and emits a rudimentary DOT representation of
+possible haplotypes for a given region. The implementation is intentionally
+minimal and only suitable for small test VCFs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pysam
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser("hapenum")
+    parser.add_argument("vcf", help="Input VCF file")
+    parser.add_argument("-r", "--reference", required=True, help="Reference FASTA")
+    parser.add_argument("-l", "--location", required=True, help="Genomic location")
+    parser.add_argument("--output-dot", required=True, help="Output DOT file")
+    return parser.parse_args(argv)
+
+
+def _enumerate(vcf: pysam.VariantFile, region: str, out_dot: Path) -> None:
+    chrom, *rest = region.replace("chr", "").split(":")
+    start = 1
+    if rest:
+        start = int(rest[0].split("-")[0])
+    nodes = []
+    edges = []
+    idx = 0
+    nodes.append(
+        f'node_{idx}  [label="start: {chrom}:{start}", shape=diamond, penwidth=2, color=cadetblue4] ;'
+    )
+    prev = [idx]
+    for rec in vcf.fetch(region=region):
+        idx += 1
+        nodes.append(
+            f"node_{idx}  [label=\"alt: {','.join(rec.alts)} {rec.chrom}:{rec.pos}-{rec.stop-1}\", shape=parallelogram, penwidth=2, color=cadetblue4] ;"
+        )
+        for p in prev:
+            edges.append(f"node_{p} -> node_{idx} [] ;")
+        prev = [idx]
+    idx += 1
+    nodes.append(
+        f"node_{idx}  [label=\"end: {chrom}:{rec.stop-1 if 'rec' in locals() else start}\", shape=triangle, penwidth=2, color=cadetblue4] ;"
+    )
+    for p in prev:
+        edges.append(f"node_{p} -> node_{idx} [] ;")
+    with open(out_dot, "w", encoding="utf-8") as out:
+        out.write("digraph G {\n")
+        for n in nodes:
+            out.write(n + "\n")
+        out.write("\n")
+        for e in edges:
+            out.write(e + "\n")
+        out.write("}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    vcf = pysam.VariantFile(args.vcf)
+    _enumerate(vcf, args.location, Path(args.output_dot))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/hap_py/utils/multimerge.py
+++ b/src/hap_py/utils/multimerge.py
@@ -1,0 +1,83 @@
+"""Simplified multimerge implementation.
+
+This module provides a minimal Python implementation of the old C++ multimerge
+utility. It currently performs a very basic merge of multiple VCF files using
+pysam as a reference implementation. The goal is to provide enough
+functionality for testing and compatibility with the previous interface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pysam
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser("multimerge")
+    parser.add_argument("inputs", nargs="+", help="VCF files in the form file:sample")
+    parser.add_argument("-o", "--output", required=True, help="Output VCF file")
+    parser.add_argument("-r", "--reference", required=True, help="Reference FASTA")
+    return parser.parse_args(argv)
+
+
+def _read_vcf(path: Path) -> pysam.VariantFile:
+    return pysam.VariantFile(str(path))
+
+
+def _merge_records(
+    inputs: list[tuple[Path, str]], out_vcf: Path, reference: Path
+) -> None:
+    header = None
+    samples = []
+    records: dict[tuple[str, int, str], pysam.VariantRecord] = {}
+
+    for vcf_path, sample in inputs:
+        vcf = _read_vcf(vcf_path)
+        if header is None:
+            header = vcf.header.copy()
+        if sample not in header.samples:
+            header.add_sample(sample)
+        samples.append(sample)
+        for rec in vcf.fetch():
+            key = (rec.chrom, rec.pos, rec.ref)
+            if key not in records:
+                new_rec = header.new_record(
+                    contig=rec.chrom,
+                    start=rec.pos - 1,
+                    stop=rec.stop,
+                    id=rec.id,
+                    ref=rec.ref,
+                    alts=list(rec.alts),
+                )
+                records[key] = new_rec
+            else:
+                new_rec = records[key]
+                alts = set(new_rec.alts or [])
+                alts.update(rec.alts or [])
+                new_rec.alts = list(alts)
+            gt = rec.samples[0].get("GT")
+            records[key].samples[sample]["GT"] = gt
+    with pysam.VariantFile(str(out_vcf), "w", header=header) as out:
+        for rec in sorted(records.values(), key=lambda r: (r.contig, r.pos)):
+            out.write(rec)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    inputs = []
+    for spec in args.inputs:
+        if ":" in spec:
+            path, sample = spec.split(":", 1)
+        else:
+            path = spec
+            sample = Path(path).stem
+        inputs.append((Path(path), sample))
+    _merge_records(inputs, Path(args.output), Path(args.reference))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add wrapper scripts in `build/bin` for preprocess, quantify, hapcmp, multimerge and hapenum
- implement minimal placeholder Python modules for `multimerge` and `hapenum`
- expose util package for future expansion

## Testing
- `pre-commit run --files build/bin/hapcmp build/bin/hapenum build/bin/multimerge build/bin/preprocess build/bin/quantify src/hap_py/utils/multimerge.py src/hap_py/utils/hapenum.py src/hap_py/utils/__init__.py`
- `python tests/test_cli_tools.py` *(fails: hap.py and quantify exit with errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841b04a9648832c93d3f926bebe3942