### PR TITLE
Fix complement_sequence mocks and README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ to benchmark variant calls against gold standard truth datasets.
 > See the [Python 3 migration guide](doc/python3_migration.md)
 > for details about the migration and compatibility.
 
-To compare a VCF against a gold standard dataset, use the following commmand line
+To compare a VCF against a gold standard dataset, use the following command line
 to perform genotype-level haplotype comparison.
 
 ```bash

--- a/src/hap_py/haplo/cython/mock__internal.py
+++ b/src/hap_py/haplo/cython/mock__internal.py
@@ -23,5 +23,16 @@ def test_basic_functionality():
     return "Mock basic functionality working"
 
 
+def complement_sequence(sequence: str) -> str:
+    """Return the DNA complement for a sequence."""
+    trans = str.maketrans("ACGTacgt", "TGCAtgca")
+    return sequence.translate(trans)
+
+
+def reverse_complement(sequence: str) -> str:
+    """Return the reverse complement of a sequence."""
+    return complement_sequence(sequence)[::-1]
+
+
 # Add mock implementations of the functions in the Cython module
 # TODO: Analyze the original module and add appropriate mock functions

--- a/src/hap_py/haplo/cython/mock_cpp_internal.py
+++ b/src/hap_py/haplo/cython/mock_cpp_internal.py
@@ -23,5 +23,16 @@ def test_basic_functionality():
     return "Mock basic functionality working"
 
 
+def complement_sequence(sequence: str) -> str:
+    """Return the DNA complement for a sequence."""
+    trans = str.maketrans("ACGTacgt", "TGCAtgca")
+    return sequence.translate(trans)
+
+
+def reverse_complement(sequence: str) -> str:
+    """Return the reverse complement of a sequence."""
+    return complement_sequence(sequence)[::-1]
+
+
 # Add mock implementations of the functions in the Cython module
 # TODO: Analyze the original module and add appropriate mock functions


### PR DESCRIPTION
## Summary
- correct spelling of "command" in README
- add `complement_sequence` and `reverse_complement` to mock Cython modules

## Testing
- `pytest tests/test_string_handling.py::test_cython_mock_import -q`
- `pytest -k complement_sequence -q` *(fails: ModuleNotFoundError: No module named 'hap_py.haplo.variant_processor')*

------
https://chatgpt.com/codex/tasks/task_e_6841cd83feb4832c88a5e0b982360c40