### PR TITLE
Set mock environment variable for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ These fixtures provide test resources for integration tests of the hap.py toolki
 """
 
 import os
+
+os.environ.setdefault("HAPLO_USE_MOCK", "1")
 import shutil
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- ensure `HAPLO_USE_MOCK` defaults to `1` in the test suite

## Testing
- `ruff check tests/conftest.py --fix`
- `pytest tests/unit/test_ga4gh_validation.py -q` *(fails: ModuleNotFoundError: No module named 'sequence_utils')*

------
https://chatgpt.com/codex/tasks/task_e_6841d1fdd264832c824bb0938730ae8d