### PR TITLE
Fix cython_compat fallback import

### DIFF
--- a/src/hap_py/haplo/cython_compat.py
+++ b/src/hap_py/haplo/cython_compat.py
@@ -22,13 +22,8 @@ def import_with_fallback(
         The imported object or its mock implementation
     """
     if mock_module is None:
-        # Use relative import for mock module when within package
-        try:
-            from . import cython_mock  # noqa: F401
-
-            mock_module = "cython_mock"
-        except ImportError:
-            mock_module = "hap_py.haplo.cython_mock"
+        # Default to the local cython_mock module
+        mock_module = "cython_mock"
 
     try:
         # Try to import the Cython module
@@ -52,7 +47,10 @@ def import_with_fallback(
                 module = __import__(mock_module, fromlist=["*"])
         except ImportError:
             # Fallback to local mock implementations
-            from .cython import mock_cpp_internal as module
+            try:
+                from . import cython_mock as module
+            except ImportError:
+                from .cython import mock_internal as module
 
         obj = getattr(module, mock_attribute)
         return obj


### PR DESCRIPTION
## Summary
- use `cython_mock` in the fallback path for `import_with_fallback`
- try `cython.mock_internal` if `cython_mock` can't be imported

## Testing
- `pytest tests/test_root_py3_compatibility.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d1fc8100832c80e3fd9a9f8acbc2