### PR TITLE
Docs: clean up environment instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,7 +49,7 @@ This fork aims to modernize the codebase for continued use and development.
     - ✅ **Completed Analysis**: Comprehensive review of current quantify module implementation status
     - ✅ **Architecture Review**: Analyzed original C++ vs modernized Python implementation differences
     - ✅ **Gap Analysis**: Identified missing critical components including `_match_variants` method
-    - ✅ **Development Plan**: Created comprehensive implementation roadmap (see `QUANTIFY_IMPLEMENTATION_PLAN.md`)
+    - ✅ **Development Plan**: Created comprehensive implementation roadmap (see `.github/prompt/quantify-development.prompt.md`)
     - ✅ **Phase 1**: Core variant matching implementation (`_match_variants` method, benchmarking decision tracking)
         - ✅ Fixed critical test failures related to allele compatibility, variant classification, and performance.
         - ✅ Enhanced method compatibility to properly handle both pandas Series and dictionary inputs
@@ -403,7 +403,7 @@ cmake --build build --config Release
     - ✅ **Completed Analysis**: Comprehensive review of current quantify module implementation status
     - ✅ **Architecture Review**: Analyzed original C++ vs modernized Python implementation differences
     - ✅ **Gap Analysis**: Identified critical components including sophisticated variant matching algorithms
-    - ✅ **Development Plan**: Created comprehensive implementation roadmap (see `QUANTIFY_IMPLEMENTATION_PLAN.md`)
+    - ✅ **Development Plan**: Created comprehensive implementation roadmap (see `.github/prompt/quantify-development.prompt.md`)
     - ✅ **Phase 1**: Core variant matching implementation (`_match_variants` method, benchmarking decision tracking)
         - ✅ Fixed critical test failures related to allele compatibility, variant classification, and performance.
         - ✅ Enhanced method compatibility to properly handle both pandas Series and dictionary inputs

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -2,16 +2,16 @@
 
 ## ✅ Environment Status: READY
 
-The `happy-dev` micromamba environment has been successfully configured for hap.py development.
+Create and activate a `happy-dev` environment with **conda** or **mamba** for hap.py development.
 
 ## Environment Details
 
 - **Environment Name**: `happy-dev`
 - **Python Version**: 3.11.12
-- **Python Location**: `/Users/nolson/micromamba/envs/happy-dev/bin/python`
+- **Python Location**: `$CONDA_PREFIX/bin/python`
 - **Package Installation**: Normal install in site-packages
 - **Testing Framework**: pytest 8.3.5
-- **RTG Tools**: Available at `/Users/nolson/hap.py-modern-claude4/hap.py/external/rtg-tools-3.12.1/rtg`
+- **RTG Tools**: Available at `$PROJECT_ROOT/external/rtg-tools-3.12.1/rtg` (or from Bioconda)
 
 ## System Dependencies
 
@@ -22,11 +22,21 @@ libraries are present. On Debian/Ubuntu systems these can be installed with:
 sudo apt-get install -y build-essential python3-dev cmake zlib1g-dev libbz2-dev libboost-all-dev
 ```
 
+## RTG Tools Installation
+
+Install `rtg-tools` from Bioconda if it is not already available in the `external` directory:
+
+```bash
+mamba install -c bioconda rtg-tools
+```
+
+After installation the executable will be found at `$CONDA_PREFIX/bin/rtg`.
+
 ## Required Activation Command
 
 **ALWAYS run this before any development work:**
 ```bash
-micromamba activate happy-dev
+conda activate happy-dev
 ```
 
 ## Verification Commands
@@ -48,7 +58,7 @@ python -c "import pytest; print(f'✅ pytest {pytest.__version__} available')"
 
 1. **Activate Environment**:
    ```bash
-   micromamba activate happy-dev
+   conda activate happy-dev
    ```
 
 2. **Run Tests**:
@@ -76,4 +86,4 @@ Following the instructions from the prompt files:
 
 ## Next Steps
 
-The environment is ready for continuing work on the quantify module implementation as outlined in `QUANTIFY_IMPLEMENTATION_PLAN.md`.
+The environment is ready for continuing work on the quantify module implementation as outlined in `.github/prompt/quantify-development.prompt.md`.


### PR DESCRIPTION
## Summary
- describe a generic conda/mamba environment setup
- use `$CONDA_PREFIX` in place of hard-coded user paths
- document Bioconda install for `rtg-tools`
- link to `quantify-development.prompt.md`

## Testing
- `pre-commit run --files ENVIRONMENT_SETUP.md .github/copilot-instructions.md`
- `pytest -q tests/unit` *(fails: ModuleNotFoundError: No module named 'pysam')*

------
https://chatgpt.com/codex/tasks/task_e_6841dbfb2134832ca23038839820465c