### PR TITLE
Fix README references to Python3 migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,9 +501,7 @@ This project is undergoing a migration to Python 3. Key goals include:
 
 For more details, see:
 
-* [Migration Status](PYTHON3_MIGRATION_FINAL.md) - Current state and test plan.
-* [Migration Tools](PYTHON3_MIGRATION_TOOLS.md) - Tools for fixing remaining issues (if applicable, link may be outdated).
-* [Core Documentation](PYTHON3_CORE.md) - Technical details of the Python 3 implementation (if applicable, link may be outdated).
+* [Python 3 Migration Guide](doc/python3_migration.md) - Comprehensive guide covering migration status, tools, and technical details.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary
- remove obsolete links to PYTHON3_MIGRATION_FINAL.md, PYTHON3_MIGRATION_TOOLS.md, and PYTHON3_CORE.md
- point to new doc/python3_migration.md

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hap_py.haplo.variant_processor')*

------
https://chatgpt.com/codex/tasks/task_e_6841dbf3aef8832cb373cf9c1a768b9c