### PR TITLE
Simplify RTG detection

### DIFF
--- a/src/hap_py/haplo/vcfeval.py
+++ b/src/hap_py/haplo/vcfeval.py
@@ -43,60 +43,32 @@ except ImportError:
 
 
 def findVCFEval() -> str:
-    """Return default version of rtgtools if hap.py was built with rtgtools included.
+    """Return the path to the ``rtg`` executable.
 
-    Returns:
-        Path to rtg executable or 'rtg' if not found
+    The search order is:
+    1. Environment variable ``RTG_PATH``.
+    2. ``rtg`` found in the user's ``PATH``.
+
+    If neither is found, ``"rtg"`` is returned so that the caller can rely on the
+    system ``PATH``.
     """
-    # Always check for our included RTG tools first, regardless of has_vcfeval flag
-    script_dir = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 
-    # For modernized version, look in external/rtg-tools-3.12.1/
-    project_root = os.path.abspath(
-        os.path.join(
-            script_dir,  # haplo
-            "..",  # hap_py
-            "..",  # src
-            "..",  # project root
+    rtg_env = os.environ.get("RTG_PATH")
+    if rtg_env and os.path.isfile(rtg_env) and os.access(rtg_env, os.X_OK):
+        logging.info("Using RTG tools from RTG_PATH: %s", rtg_env)
+        return rtg_env
+
+    rtg_in_path = shutil.which("rtg")
+    if rtg_in_path:
+        logging.info("Using RTG tools from PATH: %s", rtg_in_path)
+        return rtg_in_path
+
+    if has_vcfeval:
+        logging.warning(
+            "RTG tools not found via RTG_PATH or PATH. "
+            "Falling back to 'rtg'."
         )
-    )
-
-    # Check for RTG tools in external directory (modernized version)
-    external_rtg = os.path.join(project_root, "external", "rtg-tools-3.12.1", "rtg")
-    if os.path.isfile(external_rtg) and os.access(external_rtg, os.X_OK):
-        logging.info(f"Using RTG tools from external directory: {external_rtg}")
-        return external_rtg
-
-    # Fallback to legacy paths
-    base = os.path.abspath(
-        os.path.join(
-            script_dir,  # Haplo
-            "..",  # python
-            "..",  # src
-            "..",  # hap.py-base
-            "libexec",
-            "rtg-tools-install",
-        )
-    )
-    # prefer wrapper when it's there
-    bfile = os.path.join(base, "rtg-wrapper.sh")
-    bfile2 = os.path.join(base, "rtg")
-    if os.path.isfile(bfile) and os.access(bfile, os.X_OK):
-        logging.info(f"Using included RTG tools wrapper: {bfile}")
-        return bfile
-    elif os.path.isfile(bfile2) and os.access(bfile2, os.X_OK):
-        logging.info(f"Using included RTG tools binary: {bfile2}")
-        return bfile2
-    else:
-        # Fallback to checking if has_vcfeval is set
-        if has_vcfeval:
-            logging.warning(
-                f"Could not find our included version of rtg-tools at {base} or {external_rtg}. "
-                "To use vcfeval for comparison, you might have to specify "
-                "its location on the command line."
-            )
-        # default: return
-        return "rtg"
+    return "rtg"
 
 
 def runVCFEval(


### PR DESCRIPTION
## Summary
- remove legacy `libexec/rtg-tools-install` search logic
- rely on `RTG_PATH` env var or PATH when finding RTG

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -k vcfeval -q` *(fails: ModuleNotFoundError: No module named 'hap_py.haplo.variant_processor')*


------
https://chatgpt.com/codex/tasks/task_e_6841de3ed470832c9f85cf1a42e2ecda