### PR TITLE
Add environment-dev.yml for ROC tools

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -22,6 +22,23 @@ libraries are present. On Debian/Ubuntu systems these can be installed with:
 sudo apt-get install -y build-essential python3-dev cmake zlib1g-dev libbz2-dev libboost-all-dev
 ```
 
+## Creating the Environment
+
+Use the provided `environment-dev.yml` file to create a micromamba or conda
+environment with the optional ROC and testing packages:
+
+```bash
+micromamba env create -f environment-dev.yml
+# or
+conda env create -f environment-dev.yml
+```
+
+Activate the environment before development:
+
+```bash
+micromamba activate happy-dev
+```
+
 ## Required Activation Command
 
 **ALWAYS run this before any development work:**

--- a/README.md
+++ b/README.md
@@ -381,6 +381,21 @@ Debian/Ubuntu systems the required packages can be installed with:
 sudo apt-get install -y build-essential python3-dev cmake zlib1g-dev libbz2-dev libboost-all-dev
 ```
 
+### Development environment
+
+An `environment-dev.yml` file is provided for creating a conda or
+micromamba environment with optional packages used for ROC analysis and
+testing (Matplotlib, Seaborn, scikit-learn, etc.). Create the environment
+with:
+
+```bash
+micromamba env create -f environment-dev.yml
+# or
+conda env create -f environment-dev.yml
+
+micromamba activate happy-dev
+```
+
 ### Building from Source (Advanced)
 
 If you need to build from source and `pip install .` does not meet your needs (e.g., you need to customize the C++ build process extensively or are working in an environment without pip):

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,0 +1,22 @@
+name: happy-dev
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.11
+  - numpy
+  - pandas
+  - psutil
+  - pysam
+  - scipy
+  - bx-python
+  - biopython
+  - matplotlib
+  - seaborn
+  - scikit-learn
+  - pytest
+  - pytest-cov
+  - nose
+  - pip
+  - pip:
+      - -e .[dev,cpp]


### PR DESCRIPTION
## Summary
- add conda `environment-dev.yml` for ROC plotting and tests
- document the new environment file in `README.md`
- update `ENVIRONMENT_SETUP.md` with instructions on using `environment-dev.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hap_py.haplo.variant_processor')*

------
https://chatgpt.com/codex/tasks/task_e_6841de38d370832cb69deb40e897d4af