### PR TITLE
Remove obsolete preprocessing window option

### DIFF
--- a/doc/normalisation.md
+++ b/doc/normalisation.md
@@ -120,15 +120,6 @@ test if a given VCF can be translated into BCF.
                         header.
 ```
 
-When left-shifting and pre-blocking, we will assume that variants that are further
-apart than the following window size will not interact w.r.t. haplotype representations.
-The default value is 10000, which should be sufficient for short reads.
-
-```
-  -w WINDOW, --window-size WINDOW
-                        Preprocessing window size (variants further apart than
-                        that size are not expected to interfere).
-```
 
 The presence of the <NON_REF> symbolic allele in genome VCFs can cause problems
 for hap.py, especially if it is part of a genotype. As a workaround, we

--- a/src/hap_py/hap.py
+++ b/src/hap_py/hap.py
@@ -137,14 +137,6 @@ def main() -> int:
         default=False,
         help="Use filtered variant calls in truth file (by default, only PASS calls in the truth file are used)",
     )
-    ## %%TODO: Remove preprocess windowing as it causes unnecessary overhead and seems error prone.
-    parser.add_argument(
-        "--preprocessing-window-size",
-        dest="preprocess_window",
-        default=10000,
-        type=int,
-        help="Preprocessing window size (variants further apart than that size are not expected to interfere).",
-    )
     parser.add_argument(
         "--adjust-conf-regions",
         dest="preprocessing_truth_confregions",
@@ -368,7 +360,6 @@ def main() -> int:
             args.preprocessing_leftshift if args.preprocessing_truth else False,
             args.preprocessing_decompose if args.preprocessing_truth else False,
             args.preprocessing_norm if args.preprocessing_truth else False,
-            args.preprocess_window,
             args.threads,
             args.gender,
             False,
@@ -442,7 +433,6 @@ def main() -> int:
             args.preprocessing_leftshift,
             args.preprocessing_decompose,
             args.preprocessing_norm,
-            args.preprocess_window,
             args.threads,
             args.gender,  # same gender as truth above
             False,

--- a/src/hap_py/haplo/partialcredit.py
+++ b/src/hap_py/haplo/partialcredit.py
@@ -151,7 +151,6 @@ def partialCredit(
     reference: str,
     locations: Optional[Union[str, List[str]]] = None,
     threads: int = 1,
-    window: int = 10000,
     leftshift: bool = True,
     decompose: bool = True,
     haploid_x: bool = False,
@@ -164,7 +163,6 @@ def partialCredit(
         reference: Reference FASTA
         locations: List of regions or comma-separated string of regions
         threads: Number of threads to use
-        window: Window size for blocksplit
         leftshift: Enable left-shifting of variants
         decompose: Decompose complex variants
         haploid_x: Treat X chromosome as haploid
@@ -194,7 +192,7 @@ def partialCredit(
             pool,
             directProcessWrapper,
             locations,
-            {"vcf": vcfname, "dist": window, "pieces": min(40, threads * 4)},
+            {"vcf": vcfname, "pieces": min(40, threads * 4)},
         )
 
         # Direct processing - no splitting means no failures to filter

--- a/src/hap_py/pre.py
+++ b/src/hap_py/pre.py
@@ -94,7 +94,6 @@ def preprocess(
     leftshift: bool = True,
     decompose: bool = True,
     bcftools_norm: bool = False,
-    windowsize: int = 10000,
     threads: int = 1,
     gender: Optional[str] = None,
     somatic_allele_conversion: Union[bool, str] = False,
@@ -115,7 +114,6 @@ def preprocess(
     :param leftshift: left-shift variants
     :param decompose: decompose variants
     :param bcftools_norm: use bcftools_norm
-    :param windowsize: normalisation window size
     :param threads: number of threads to for preprcessing
     :param gender: the sex of the sample ("male" / "female" / "auto" / None)
     :param somatic_allele_conversion: convert somatic alleles -- False / half / het / hemi / hom
@@ -269,7 +267,6 @@ def preprocess(
                 reference,
                 locations,
                 threads=threads,
-                window=windowsize,
                 leftshift=leftshift,
                 decompose=decompose,
                 haploid_x=gender == "male",
@@ -305,7 +302,6 @@ def preprocessWrapper(args: argparse.Namespace) -> None:
         args.preprocessing_leftshift,
         args.preprocessing_decompose,
         args.preprocessing_norm,
-        args.window,
         args.threads,
         args.gender,
         args.somatic_allele_conversion,
@@ -508,15 +504,6 @@ def main() -> int:
         dest="ref",
         help="Specify a reference file.",
         default=None,
-    )
-
-    parser.add_argument(
-        "-w",
-        "--window-size",
-        dest="window",
-        default=10000,
-        type=int,
-        help="Preprocessing window size (variants further apart than that size are not expected to interfere).",
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Summary
- drop `--preprocessing-window-size` from `hap.py`
- simplify preprocessing API and remove window size handling
- update docs to remove mention of the window size option
- format code

## Testing
- `ruff check src/hap_py/hap.py src/hap_py/pre.py src/hap_py/haplo/partialcredit.py doc/normalisation.md`
- `black --check src/hap_py/hap.py src/hap_py/pre.py src/hap_py/haplo/partialcredit.py`
- `pytest -q` *(fails: AssertionError and subprocess errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841de325368832cba6405d606359552