### PR TITLE
Implement Python fallbacks and update tests

### DIFF
--- a/src/hap_py/haplo/cython/mock__internal.py
+++ b/src/hap_py/haplo/cython/mock__internal.py
@@ -33,6 +33,22 @@ def reverse_complement(sequence: str) -> str:
     """Return the reverse complement of a sequence."""
     return complement_sequence(sequence)[::-1]
 
+def get_version() -> str:
+    """Return a mock hap.py version string."""
+    return "0.0.mock"
 
-# Add mock implementations of the functions in the Cython module
-# TODO: Analyze the original module and add appropriate mock functions
+
+def get_build_time() -> str:
+    """Return a mock build timestamp."""
+    return "1970-01-01T00:00:00"
+
+
+def is_available() -> bool:
+    """Indicate that the mock implementation is available."""
+    return True
+
+
+def test_module() -> dict:
+    """Test if the module is working properly."""
+    return {"version": get_version(), "build_time": get_build_time()}
+

--- a/src/hap_py/haplo/cython/mock_cpp_internal.py
+++ b/src/hap_py/haplo/cython/mock_cpp_internal.py
@@ -33,6 +33,40 @@ def reverse_complement(sequence: str) -> str:
     """Return the reverse complement of a sequence."""
     return complement_sequence(sequence)[::-1]
 
+def get_version() -> str:
+    """Return a mock hap.py version string."""
+    return "0.0.mock"
 
-# Add mock implementations of the functions in the Cython module
-# TODO: Analyze the original module and add appropriate mock functions
+
+def get_git_hash() -> str:
+    """Return a mock git hash."""
+    return "mock-hash"
+
+
+def get_build_time() -> str:
+    """Return a mock build timestamp."""
+    return "1970-01-01T00:00:00"
+
+
+class PyVariant:
+    """Simple stand-in for the C++ Variant class."""
+
+    def __init__(self, chrom: str, pos: int, ref: str, alt: str):
+        self.chrom = chrom
+        self.pos = pos
+        self.ref = ref
+        self.alt = alt
+        self.qual = 0.0
+
+    def __str__(self) -> str:
+        return f"{self.chrom}:{self.pos} {self.ref}>{self.alt}"
+
+
+def test_module() -> dict:
+    """Test if the module is working properly."""
+    return {
+        "version": get_version(),
+        "build_time": get_build_time(),
+        "git_hash": get_git_hash(),
+    }
+

--- a/src/hap_py/haplo/variant_processor.py
+++ b/src/hap_py/haplo/variant_processor.py
@@ -1,0 +1,39 @@
+"""Pure Python fallback for the VariantProcessor Cython module."""
+
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class Variant:
+    chrom: str
+    pos: int
+    ref: str
+    alt: str
+
+class VariantProcessor:
+    """Simplified Python implementation of VariantProcessor."""
+
+    def __init__(self) -> None:
+        self.variants: List[Variant] = []
+
+    def add_variant(self, variant: Variant) -> None:
+        self.variants.append(variant)
+
+    def get_variant_chrom(self, idx: int) -> str:
+        if idx >= len(self.variants):
+            raise IndexError(f"Index {idx} out of range")
+        return self.variants[idx].chrom
+
+    def process_variants(self, threads: int = 1):
+        results = []
+        for var in self.variants:
+            results.append(
+                {
+                    "chrom": var.chrom,
+                    "position": var.pos,
+                    "ref": var.ref,
+                    "alt": var.alt,
+                    "processed": True,
+                }
+            )
+        return results

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,6 @@ These fixtures provide test resources for integration tests of the hap.py toolki
 """
 
 import os
-
-os.environ.setdefault("HAPLO_USE_MOCK", "1")
 import shutil
 from pathlib import Path
 

--- a/tests/test_happy_integration.py
+++ b/tests/test_happy_integration.py
@@ -25,7 +25,6 @@ def test_happy_basic_cli(sample_vcf_files, sample_reference, tmp_path):
 
     # Run hap.py with mock environment to avoid requirement C++ components
     env = os.environ.copy()
-    env["HAPLO_USE_MOCK"] = "1"
 
     # Run the command
     cmd = [
@@ -76,7 +75,6 @@ def test_happy_with_bed_file(
 
     # Run hap.py with mock environment
     env = os.environ.copy()
-    env["HAPLO_USE_MOCK"] = "1"
 
     # Run the command with BED file
     cmd = [
@@ -125,7 +123,6 @@ def test_error_handling(sample_vcf_files, tmp_path):
 
     # Run hap.py with mock environment
     env = os.environ.copy()
-    env["HAPLO_USE_MOCK"] = "1"
 
     # Run the command with non-existent reference
     cmd = [

--- a/tests/test_qfy_integration.py
+++ b/tests/test_qfy_integration.py
@@ -43,7 +43,6 @@ chr1	400	.	T	A	.	PASS	Type=SNP;Subtype=SNP;FP	GT	./.	0/1
 
     # Run qfy.py with mock environment
     env = os.environ.copy()
-    env["HAPLO_USE_MOCK"] = "1"
 
     # Run the command
     cmd = [
@@ -106,7 +105,6 @@ chr1	500	.	G	T	.	PASS	Type=SNP;Subtype=SNP;FP;QQ=50	GT	./.	0/1
 
     # Run qfy.py with mock environment
     env = os.environ.copy()
-    env["HAPLO_USE_MOCK"] = "1"
 
     # Run the command with ROC output
     cmd = [

--- a/tests/test_root_py3_compatibility.py
+++ b/tests/test_root_py3_compatibility.py
@@ -32,31 +32,13 @@ def test_string_handling_module():
 
 def test_cython_mock_import():
     """Test using mock Cython implementations."""
-    # Store original environment value
-    original_value = os.environ.get("HAPLO_USE_MOCK", None)
+    from hap_py.haplo import cython_mock as cython_module
 
-    try:
-        # Set environment variable to use mocks
-        os.environ["HAPLO_USE_MOCK"] = "1"
+    seq = "ACGTACGT"
+    comp_seq = cython_module.complement_sequence(seq)
+    assert comp_seq == "TGCATGCA"
 
-        # Import the Cython module package
-        from hap_py.haplo import cython_mock as cython_module
-
-        # Test complement_sequence function
-        seq = "ACGTACGT"
-        comp_seq = cython_module.complement_sequence(seq)
-        assert comp_seq == "TGCATGCA"
-
-        # Test with bytes input (Python 3 compatibility test)
-        bytes_seq = b"ACGT"
-        str_result = cython_module.complement_sequence(bytes_seq)
-        # Mock returns bytes when given bytes
-        assert isinstance(str_result, bytes)
-        assert str_result == b"TGCA"
-
-    finally:
-        # Restore original environment
-        if original_value is None:
-            del os.environ["HAPLO_USE_MOCK"]
-        else:
-            os.environ["HAPLO_USE_MOCK"] = original_value
+    bytes_seq = b"ACGT"
+    str_result = cython_module.complement_sequence(bytes_seq)
+    assert isinstance(str_result, bytes)
+    assert str_result == b"TGCA"

--- a/tests/test_string_handling.py
+++ b/tests/test_string_handling.py
@@ -28,83 +28,47 @@ def test_string_handling_module():
 
 def test_cython_mock_import():
     """Test using mock Cython implementations."""
-    # Store original environment value
-    original_value = os.environ.get("HAPLO_USE_MOCK", None)
+    import src.hap_py.haplo.cython as haplo_cython
 
-    try:
-        # Set environment variable to use mocks
-        os.environ["HAPLO_USE_MOCK"] = "1"
+    assert haplo_cython.USING_MOCK is True
 
-        # Import the Cython module package
-        import src.hap_py.haplo.cython as haplo_cython
+    seq = "ACGTACGT"
+    comp_seq = haplo_cython.complement_sequence(seq)
+    assert comp_seq == "TGCATGCA"
 
-        # Verify we're using mocks
-        assert haplo_cython.USING_MOCK is True
-
-        # Test complement_sequence function
-        seq = "ACGTACGT"
-        comp_seq = haplo_cython.complement_sequence(seq)
-        assert comp_seq == "TGCATGCA"
-
-        # Test with bytes input (Python 3 compatibility test)
-        bytes_seq = b"ACGT"
-        str_result = haplo_cython.complement_sequence(bytes_seq)
-        assert isinstance(str_result, str)
-        assert str_result == "TGCA"
-
-    finally:
-        # Restore original environment
-        if original_value is None:
-            del os.environ["HAPLO_USE_MOCK"]
-        else:
-            os.environ["HAPLO_USE_MOCK"] = original_value
+    bytes_seq = b"ACGT"
+    str_result = haplo_cython.complement_sequence(bytes_seq)
+    assert isinstance(str_result, str)
+    assert str_result == "TGCA"
 
 
 def test_mock_variant_classes():
     """Test the mock variant record and comparison classes."""
-    # Store original environment value
-    original_value = os.environ.get("HAPLO_USE_MOCK", None)
+    import src.hap_py.haplo.cython as haplo_cython
 
-    try:
-        # Set environment variable to use mocks
-        os.environ["HAPLO_USE_MOCK"] = "1"
+    record = haplo_cython.MockVariantRecord(
+        chrom="chr1", pos=100, ref="A", alt="T", qual=30
+    )
+    assert record.chrom == "chr1"
+    assert record.pos == 100
+    assert record.ref == "A"
+    assert record.alt == "T"
+    assert str(record) == "chr1:100 A>T"
 
-        # Import the Cython module package
-        import src.hap_py.haplo.cython as haplo_cython
+    comparator = haplo_cython.MockHaploCompare()
+    comparator.add_truth_variant(record)
+    comparator.add_query_variant(record)
+    results = comparator.compare()
 
-        # Test record class
-        record = haplo_cython.MockVariantRecord(
-            chrom="chr1", pos=100, ref="A", alt="T", qual=30
-        )
-        assert record.chrom == "chr1"
-        assert record.pos == 100
-        assert record.ref == "A"
-        assert record.alt == "T"
-        assert str(record) == "chr1:100 A>T"
+    assert "total_truth" in results
+    assert "total_query" in results
+    assert results["total_truth"] == 1
+    assert results["total_query"] == 1
 
-        # Test mock comparison
-        comparator = haplo_cython.MockHaploCompare()
-        comparator.add_truth_variant(record)
-        comparator.add_query_variant(record)
-        results = comparator.compare()
+    tp_key = next(
+        (k for k in results if k.lower().replace("_", "") == "truepositives"),
+        None,
+    )
+    assert tp_key is not None, "No true positives key found in results"
+    assert results[tp_key] == 1
 
-        # Check the results - ensure they have expected keys
-        assert "total_truth" in results
-        assert "total_query" in results
-        assert results["total_truth"] == 1
-        assert results["total_query"] == 1
-
-        # Check either true_positives or true_positives are present
-        # (allowing either naming convention)
-        tp_key = next(
-            (k for k in results if k.lower().replace("_", "") == "truepositives"), None
-        )
-        assert tp_key is not None, "No true positives key found in results"
-        assert results[tp_key] == 1
-
-    finally:
-        # Restore original environment
-        if original_value is None:
-            del os.environ["HAPLO_USE_MOCK"]
-        else:
-            os.environ["HAPLO_USE_MOCK"] = original_value

--- a/tests/unit/test_ga4gh_validation.py
+++ b/tests/unit/test_ga4gh_validation.py
@@ -8,8 +8,6 @@ import pytest
 project_root_path = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(project_root_path / "src"))
 
-os.environ["HAPLO_USE_MOCK"] = "1"
-
 # Ensure dummy executables for bgzip and tabix so tools.init() succeeds
 tmp_tool_dir = tempfile.mkdtemp()
 for tool in ("bgzip", "tabix"):


### PR DESCRIPTION
## Summary
- implement version and variant utilities in `mock_cpp_internal` and `mock__internal`
- add a simple `variant_processor.py` fallback
- drop `HAPLO_USE_MOCK` env var from tests and fixtures
- adjust integration tests to rely on automatic fallback

## Testing
- `pip install numpy pandas psutil pysam scipy bx-python biopython`
- `pytest -q` *(fails: FileNotFoundError: Provided engine_vcfeval path rtg does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6841de2ea2f4832c8d5742ff1f2025a9