### PR TITLE
Update RTG detection logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ next_session_prompt.md
 build*
 bin*
 .specstory/**
+.venv/
+requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ gold-standard datasets that cover difficult regions of the genome (e.g.
 subsets of the genome will be responsible for most of the difference between
 methods.
 
+### RTG vcfeval Integration
+
+hap.py relies on the external [RTG vcfeval](https://github.com/RealTimeGenomics/rtg-tools)
+binary when using the ``--engine=vcfeval`` option. The executable is located by
+checking the ``RTG`` or ``RTGTOOLS_PATH`` environment variables and then falling
+back to ``rtg`` on the ``PATH``. If the executable cannot be found, hap.py will
+raise an error. Set ``RTG`` or ``RTGTOOLS_PATH`` to the full path of the
+``rtg`` binary if it is not available globally.
+
 ### Variant preprocessing
 
 Another component of hap.py is a variant pre-processing method which

--- a/rtg
+++ b/rtg
@@ -1,1 +1,0 @@
-external/rtg-tools-3.12.1/rtg

--- a/src/hap_py/haplo/vcfeval.py
+++ b/src/hap_py/haplo/vcfeval.py
@@ -43,60 +43,46 @@ except ImportError:
 
 
 def findVCFEval() -> str:
-    """Return default version of rtgtools if hap.py was built with rtgtools included.
+    """Locate the ``rtg`` executable.
+
+    The lookup order is:
+
+    1. ``RTG`` or ``RTGTOOLS_PATH`` environment variables
+    2. ``shutil.which("rtg")``
 
     Returns:
-        Path to rtg executable or 'rtg' if not found
+        Path to the ``rtg`` executable.
+
+    Raises:
+        FileNotFoundError: if the executable cannot be located.
     """
-    # Always check for our included RTG tools first, regardless of has_vcfeval flag
-    script_dir = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 
-    # For modernized version, look in external/rtg-tools-3.12.1/
-    project_root = os.path.abspath(
-        os.path.join(
-            script_dir,  # haplo
-            "..",  # hap_py
-            "..",  # src
-            "..",  # project root
+    env_vars = ["RTG", "RTGTOOLS_PATH"]
+    for var in env_vars:
+        val = os.environ.get(var)
+        if not val:
+            continue
+
+        exe = val
+        if os.path.isdir(exe):
+            exe = os.path.join(exe, "rtg")
+
+        if os.path.isfile(exe) and os.access(exe, os.X_OK):
+            logging.info(f"Using RTG tools from ${var}: {exe}")
+            return exe
+
+        raise FileNotFoundError(
+            f"RTG executable specified via ${var} not found or not executable: {val}"
         )
-    )
 
-    # Check for RTG tools in external directory (modernized version)
-    external_rtg = os.path.join(project_root, "external", "rtg-tools-3.12.1", "rtg")
-    if os.path.isfile(external_rtg) and os.access(external_rtg, os.X_OK):
-        logging.info(f"Using RTG tools from external directory: {external_rtg}")
-        return external_rtg
+    rtg = shutil.which("rtg")
+    if rtg:
+        logging.info(f"Using RTG tools from PATH: {rtg}")
+        return rtg
 
-    # Fallback to legacy paths
-    base = os.path.abspath(
-        os.path.join(
-            script_dir,  # Haplo
-            "..",  # python
-            "..",  # src
-            "..",  # hap.py-base
-            "libexec",
-            "rtg-tools-install",
-        )
+    raise FileNotFoundError(
+        "rtg executable not found. Set RTG or RTGTOOLS_PATH or ensure it is on your PATH."
     )
-    # prefer wrapper when it's there
-    bfile = os.path.join(base, "rtg-wrapper.sh")
-    bfile2 = os.path.join(base, "rtg")
-    if os.path.isfile(bfile) and os.access(bfile, os.X_OK):
-        logging.info(f"Using included RTG tools wrapper: {bfile}")
-        return bfile
-    elif os.path.isfile(bfile2) and os.access(bfile2, os.X_OK):
-        logging.info(f"Using included RTG tools binary: {bfile2}")
-        return bfile2
-    else:
-        # Fallback to checking if has_vcfeval is set
-        if has_vcfeval:
-            logging.warning(
-                f"Could not find our included version of rtg-tools at {base} or {external_rtg}. "
-                "To use vcfeval for comparison, you might have to specify "
-                "its location on the command line."
-            )
-        # default: return
-        return "rtg"
 
 
 def runVCFEval(

--- a/src/hap_py/tools/__init__.py
+++ b/src/hap_py/tools/__init__.py
@@ -90,36 +90,26 @@ def init():
     tools_to_check = list(GA4GH_TOOLS)
 
     for x in tools_to_check:
-        found = which(x)  # Use the 'which' function defined in this file
-
-        # Special handling for rtg - check our included version
-        if not found and x == "rtg":
+        if x == "rtg":
             try:
-                # Import and use findVCFEval to check for included RTG tools
                 from ..haplo.vcfeval import findVCFEval
 
-                rtg_path = findVCFEval()
-                if (
-                    rtg_path != "rtg"
-                    and os.path.isfile(rtg_path)
-                    and os.access(rtg_path, os.X_OK)
-                ):
-                    found = rtg_path
-                    logging.info(f"Using included RTG tools at: {rtg_path}")
-            except ImportError:
-                pass  # vcfeval module not available
+                found = findVCFEval()
+            except (ImportError, FileNotFoundError) as e:
+                logging.warning(str(e))
+                if x in GA4GH_TOOLS:
+                    GA4GH_TOOLS.remove(x)
+                continue
+        else:
+            found = which(x)  # Use the 'which' function defined in this file
 
         if not found:
-            if x == "rtg":  # Specific handling for rtg
-                logging.warning(
-                    "Executable for %s not found. This is an optional " "dependency.",
-                    x,
-                )
+            if x == "rtg":
+                # Should not happen due to earlier continue, but keep safeguard
                 if x in GA4GH_TOOLS:
                     GA4GH_TOOLS.remove(x)
                 continue
 
-            # For other tools (bgzip, tabix), if not found, raise an exception.
             raise Exception(f"Dependency {x} not found")
 
 


### PR DESCRIPTION
## Summary
- remove obsolete `rtg` symlink
- ignore `.venv` and requirements-dev in git
- detect RTG via environment variables or PATH
- handle RTG resolution through new `findVCFEval` logic
- describe RTG detection in README

## Testing
- `pre-commit run --all-files` *(fails: black reformatted unrelated files)*
- `pytest -q` *(fails: 11 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6841de1aa3f4832cad11a046d7cb39ad