### PR TITLE
Clean up old RTG location

### DIFF
--- a/tests/integration/test_hapcmp.py
+++ b/tests/integration/test_hapcmp.py
@@ -38,10 +38,6 @@ def test_hapcmp(example_data_dir, temp_dir):
     if not hapcmp_bin.exists():
         pytest.skip(f"Hapcmp binary not found: {hapcmp_bin}")
 
-    # Check for RTG tools dependency
-    rtg_path = project_root / "libexec" / "rtg-tools-install"
-    if not rtg_path.exists():
-        pytest.skip("RTG tools not found. Skipping hapcmp test.")
 
     # Define input files
     hc_bed = Path(example_data_dir) / "hc.bed"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,10 +86,7 @@ def check_external_dependencies():
     """Check if required external dependencies are available."""
     project_root = get_project_root()
 
-    # Check for RTG tools
-    rtg_path = project_root / "libexec" / "rtg-tools-install"
-    if not rtg_path.exists():
-        print("Warning: RTG tools not found. Some tests may fail.")
+
 
     # Check for other required tools
     required_tools = ["bcftools", "samtools", "pysam"]


### PR DESCRIPTION
## Summary
- remove the legacy fallback in tests that looked in `libexec/rtg-tools-install`
- `findVCFEval()` now only checks the environment or PATH

## Testing
- `pytest -k vcfeval -q` *(fails: FileNotFoundError: rtg executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422a80bdd4832cbe57dd67fc21c1bc