### PR TITLE
Fix integration tests to use explicit hap.py path

### DIFF
--- a/tests/integration/test_decomp.py
+++ b/tests/integration/test_decomp.py
@@ -9,7 +9,12 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import compare_summary_files, get_example_dir, run_command
+from tests.utils import (
+    compare_summary_files,
+    get_bin_dir,
+    get_example_dir,
+    run_command,
+)
 
 
 @pytest.mark.integration
@@ -39,7 +44,7 @@ def test_decomp(tmp_path, rtg_executable, reference_file):
 
     # Run hap.py with the same parameters as in the shell script
     cmd = [
-        "hap.py",
+        str(get_bin_dir() / "hap.py"),
         str(truth_vcf),
         str(query_vcf),
         "-f",

--- a/tests/integration/test_faulty_variants.py
+++ b/tests/integration/test_faulty_variants.py
@@ -8,6 +8,8 @@ import gzip
 import subprocess
 from pathlib import Path
 
+from tests.utils import get_bin_dir
+
 import pytest
 
 
@@ -41,7 +43,7 @@ def test_faulty_variant_handling(temp_dir):
 
     # Test 1: hap.py with valid inputs
     cmd = [
-        "hap.py",
+        str(get_bin_dir() / "hap.py"),
         str(test_vcf),
         str(test_q_vcf),
         "-o",
@@ -73,7 +75,7 @@ def test_faulty_variant_handling(temp_dir):
 
     # Test 2: hap.py with faulty inputs - should fail
     cmd = [
-        "hap.py",
+        str(get_bin_dir() / "hap.py"),
         str(test_vcf),
         str(test_q_failure_vcf),
         "-o",
@@ -111,7 +113,7 @@ def test_faulty_variant_pre_py(temp_dir):
 
     # Run pre.py with faulty input - should fail
     cmd = [
-        "preprocess",
+        str(get_bin_dir() / "preprocess"),
         str(faulty_vcf),
         str(output_file),
         "--reference",

--- a/tests/integration/test_giab.py
+++ b/tests/integration/test_giab.py
@@ -9,6 +9,7 @@ import pytest
 
 from tests.utils import (
     compare_summary_files,
+    get_bin_dir,
     get_example_dir,
     run_command,
     validate_output_files,
@@ -40,7 +41,7 @@ def test_small_giab_rtg(tmp_path, rtg_executable, reference_file):
 
     # Run hap.py with the same parameters as in the shell script
     cmd = [
-        "hap.py",
+        str(get_bin_dir() / "hap.py"),
         str(nist_vcf),
         str(rtg_vcf),
         "-r",
@@ -94,7 +95,7 @@ def test_large_giab_rtg_chr21(tmp_path, rtg_executable, reference_file):
 
     # Run hap.py with the same parameters as in the shell script
     cmd = [
-        "hap.py",
+        str(get_bin_dir() / "hap.py"),
         str(nist_vcf),
         str(rtg_vcf),
         "-r",
@@ -157,7 +158,7 @@ def test_large_giab_rtg_chr1(tmp_path, rtg_executable, reference_file):
 
     # Run hap.py with the same parameters as in the shell script
     cmd = [
-        "hap.py",
+        str(get_bin_dir() / "hap.py"),
         str(nist_vcf),
         str(rtg_vcf),
         "-r",

--- a/tests/integration/test_leftshift.py
+++ b/tests/integration/test_leftshift.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from utils import get_project_root
+from utils import get_project_root, get_bin_dir
 
 
 @pytest.mark.integration
@@ -48,7 +48,7 @@ def test_leftshift(tmp_path):
 
     # Run hap.py with left-shifting
     cmd = [
-        "hap.py",
+        str(get_bin_dir() / "hap.py"),
         str(truth_vcf),
         str(query_vcf),
         "-o",

--- a/tests/integration/test_other_vcf.py
+++ b/tests/integration/test_other_vcf.py
@@ -15,6 +15,7 @@ import pytest
 
 from tests.utils import (
     compare_summary_files,
+    get_bin_dir,
     get_example_dir,
     get_project_root,
     run_command,
@@ -44,7 +45,7 @@ def test_variant_filtering(tmp_path):
 
     # Run hap.py with the same parameters as in the shell script
     cmd = [
-        "hap.py",
+        str(get_bin_dir() / "hap.py"),
         str(per_sample_ft_lhs_vcf),
         str(per_sample_ft_rhs_vcf),
         "-o",
@@ -92,7 +93,7 @@ def test_haploid_variants(tmp_path):
 
     # Run hap.py with the same parameters as in the shell script
     cmd = [
-        "hap.py",
+        str(get_bin_dir() / "hap.py"),
         str(truth_vcf),
         str(query_vcf),
         "-o",


### PR DESCRIPTION
## Summary
- use `get_bin_dir` in integration tests
- call hap.py and preprocess using explicit bin directory

## Testing
- `pytest tests/integration -q` *(fails: Dependency bgzip not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422c4faa98832caf41ad01fffe7a73