### PR TITLE
Fix RTG path in faulty variant test

### DIFF
--- a/tests/integration/test_faulty_variants.py
+++ b/tests/integration/test_faulty_variants.py
@@ -12,7 +12,7 @@ import pytest
 
 
 @pytest.mark.integration
-def test_faulty_variant_handling(temp_dir):
+def test_faulty_variant_handling(temp_dir, rtg_executable):
     """Test handling of faulty variants."""
     # Get paths to reference files
     project_root = Path(__file__).parent.parent.parent
@@ -54,7 +54,7 @@ def test_faulty_variant_handling(temp_dir):
         "-V",
         "--force-interactive",
         "--engine-vcfeval-path",
-        "/Users/nolson/hap.py-modern-claude4/hap.py/external/rtg-tools-3.12.1/rtg",
+        rtg_executable,
     ]
 
     result = subprocess.run(cmd, capture_output=True)
@@ -86,7 +86,7 @@ def test_faulty_variant_handling(temp_dir):
         "-V",
         "--force-interactive",
         "--engine-vcfeval-path",
-        "/Users/nolson/hap.py-modern-claude4/hap.py/external/rtg-tools-3.12.1/rtg",
+        rtg_executable,
     ]
 
     result = subprocess.run(cmd, capture_output=True)


### PR DESCRIPTION
## Summary
- use the `rtg_executable` fixture in `test_faulty_variant_handling`
- pass the fixture to `--engine-vcfeval-path`

## Testing
- `pytest tests/integration/test_faulty_variants.py -v` *(fails: FileNotFoundError: 'hap.py' and 'preprocess')*

------
https://chatgpt.com/codex/tasks/task_e_68422c61c8c8832cb93fe5b69b11ddf8