### PR TITLE
Use pysam for VCF compression in tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -64,6 +64,7 @@ Tests assume that:
 1. The hap.py package is installed or available in the Python path
 2. C++ components have been built (for tests with the `cpp` marker)
 3. A reference genome is available (either via `HGREF` environment variable or in the example directory)
+4. `bgzip` and `tabix` executables are available in `build/bin` or on the `PATH`. If not, the helper functions in `tests/utils.py` fall back to `pysam` for compression and indexing.
 
 ### Building the Project Before Running Tests
 

--- a/tests/integration/test_gvcf_homref.py
+++ b/tests/integration/test_gvcf_homref.py
@@ -8,35 +8,11 @@ from pathlib import Path
 import pytest
 
 from tests.utils import (
-    compare_files,
+    compress_and_index_vcf,
     get_bin_dir,
     get_example_dir,
     run_shell_command,
 )
-
-
-def compress_and_index_vcf(vcf_path: Path) -> Path:
-    """Compress and index a VCF file using bgzip and tabix.
-
-    Args:
-        vcf_path: Path to the VCF file to compress
-
-    Returns:
-        Path to the compressed VCF file
-    """
-    gz_path = vcf_path.with_suffix(".vcf.gz")
-
-    # Compress the VCF
-    cmd = f"cat {vcf_path} | bgzip > {gz_path}"
-    returncode, _, stderr = run_shell_command(cmd)
-    assert returncode == 0, f"Failed to compress VCF: {stderr}"
-
-    # Index the compressed VCF
-    cmd = f"tabix -p vcf {gz_path}"
-    returncode, _, stderr = run_shell_command(cmd)
-    assert returncode == 0, f"Failed to index VCF: {stderr}"
-
-    return gz_path
 
 
 @pytest.mark.integration

--- a/tests/integration/test_hapenum.py
+++ b/tests/integration/test_hapenum.py
@@ -8,7 +8,12 @@ import subprocess
 
 import pytest
 
-from tests.utils import get_bin_dir, get_project_root, run_command
+from tests.utils import (
+    compress_and_index_vcf,
+    get_bin_dir,
+    get_project_root,
+    run_command,
+)
 
 
 @pytest.mark.integration
@@ -36,11 +41,7 @@ def test_hapenum(tmp_path):
     assert expected_dot.exists(), f"Expected dot file {expected_dot} not found"
 
     # Compress and index the VCF file
-    bgzip_cmd = f"cat {refgraph1_vcf} | bgzip > {temp_vcf_gz}"
-    subprocess.run(bgzip_cmd, shell=True, check=True)
-
-    tabix_cmd = f"tabix -p vcf -f {temp_vcf_gz}"
-    subprocess.run(tabix_cmd, shell=True, check=True)
+    compress_and_index_vcf(refgraph1_vcf, output_path=temp_vcf_gz)
 
     # Run hapenum to generate the dot file
     hapenum_exe = bin_dir / "hapenum"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -10,6 +10,7 @@ import pytest
 
 from tests.utils import (
     compare_summary_files,
+    compress_and_index_vcf,
     find_reference_file,
     get_bin_dir,
     get_example_dir,
@@ -76,21 +77,11 @@ def test_integration(tmp_path):
 
     # Compress and index VCF files if not already compressed
     if not empty_vcf_gz.exists():
-        cmd = f"cat {empty_vcf} | bgzip > {empty_vcf_gz}"
-        run_shell_command(cmd)
-        cmd = f"tabix -f -p vcf {empty_vcf_gz}"
-        run_shell_command(cmd)
+        compress_and_index_vcf(empty_vcf, output_path=empty_vcf_gz)
 
     # Compress and index the input VCFs
-    cmd = f"cat {lhs_vcf} | bgzip > {lhs_vcf_gz}"
-    run_shell_command(cmd)
-    cmd = f"tabix -f -p vcf {lhs_vcf_gz}"
-    run_shell_command(cmd)
-
-    cmd = f"cat {rhs_vcf} | bgzip > {rhs_vcf_gz}"
-    run_shell_command(cmd)
-    cmd = f"tabix -f -p vcf {rhs_vcf_gz}"
-    run_shell_command(cmd)
+    compress_and_index_vcf(lhs_vcf, output_path=lhs_vcf_gz)
+    compress_and_index_vcf(rhs_vcf, output_path=rhs_vcf_gz)
 
     # Test multimerge functionality
     multimerge_output = tmp_path / "multimerge_output.vcf"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -360,3 +360,55 @@ def cleanup_test_files(output_prefix: str, extensions: List[str]):
                 os.remove(file_path)
         except OSError:
             pass  # Ignore cleanup errors
+
+
+def compress_and_index_vcf(vcf_path: Path, output_path: Optional[Path] = None) -> Path:
+    """Compress and index a VCF file.
+
+    If the ``bgzip`` and ``tabix`` executables are available in ``build/bin`` or
+    on the ``PATH`` they are used. Otherwise ``pysam`` is used as a fallback to
+    perform the compression and indexing.
+
+    Args:
+        vcf_path: Path to the VCF file to compress and index.
+        output_path: Optional path for the compressed file. Defaults to
+            ``vcf_path`` with ``.gz`` appended.
+
+    Returns:
+        Path to the compressed VCF file.
+    """
+
+    if output_path is None:
+        output_path = vcf_path.with_suffix(vcf_path.suffix + ".gz")
+
+    bgzip_bin = get_bin_dir() / "bgzip"
+    tabix_bin = get_bin_dir() / "tabix"
+
+    bgzip_cmd = None
+    if bgzip_bin.exists():
+        bgzip_cmd = [str(bgzip_bin), "-c", str(vcf_path)]
+    elif shutil.which("bgzip"):
+        bgzip_cmd = ["bgzip", "-c", str(vcf_path)]
+
+    if bgzip_cmd:
+        with open(output_path, "wb") as out_f:
+            subprocess.run(bgzip_cmd, check=True, stdout=out_f)
+    else:
+        import pysam
+
+        pysam.tabix_compress(str(vcf_path), str(output_path), force=True)
+
+    tabix_cmd = None
+    if tabix_bin.exists():
+        tabix_cmd = [str(tabix_bin), "-f", "-p", "vcf", str(output_path)]
+    elif shutil.which("tabix"):
+        tabix_cmd = ["tabix", "-f", "-p", "vcf", str(output_path)]
+
+    if tabix_cmd:
+        subprocess.run(tabix_cmd, check=True)
+    else:
+        import pysam
+
+        pysam.tabix_index(str(output_path), preset="vcf", force=True)
+
+    return output_path


### PR DESCRIPTION
## Summary
- add `compress_and_index_vcf` helper using pysam when bgzip/tabix are unavailable
- refactor integration tests to use this helper
- document compression fallback in the test README

## Testing
- `pytest tests/integration/test_hapenum.py::test_hapenum -q` *(fails: Command '['/workspace/hap.py/build/bin/hapenum', '-r', '/workspace/hap.py/src/data/chrQ.fa', '/tmp/pytest-of-root/pytest-1/test_hapenum0/refgraph1.vcf.gz:NA12877', '--output-dot', '/tmp/pytest-of-root/pytest-1/test_hapenum0/temp.dot', '-l', 'chrQ']' returned non-zero exit status 1.)*
- `pytest tests/integration/test_gvcf_homref.py::test_gvcf_homref -q`
- `pytest tests/integration/test_integration.py::test_integration -q` *(fails: multimerge: error: unrecognized arguments: --process-full 1)*

------
https://chatgpt.com/codex/tasks/task_e_68422c7ecff0832c9ecd31ddb794375f