### PR TITLE
Add testing dependency docs

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -64,6 +64,26 @@ python -c "from hap_py.haplo import quantify, vcfeval; print('✅ Core modules a
 python -c "import pytest; print(f'✅ pytest {pytest.__version__} available')"
 ```
 
+## Testing Dependencies
+
+These Python packages are required to run the test suite:
+
+* `numpy`
+* `pandas`
+* `pysam`
+* `scipy`
+* `bx-python`
+* `biopython`
+* `matplotlib`
+* `seaborn`
+* `scikit-learn`
+* `pytest`
+* `pytest-cov`
+* `nose`
+
+They can be installed automatically by creating the `happy-dev` environment
+from [environment-dev.yml](environment-dev.yml).
+
 ## Development Workflow
 
 1. **Activate Environment**:

--- a/README.md
+++ b/README.md
@@ -422,6 +422,10 @@ conda env create -f environment-dev.yml
 micromamba activate happy-dev
 ```
 
+Before running the tests, consult
+[ENVIRONMENT_SETUP.md](ENVIRONMENT_SETUP.md) for the full list of
+testing dependencies and activation commands.
+
 ### Building from Source (Advanced)
 
 If you need to build from source and `pip install .` does not meet your needs (e.g., you want to customize the build process or are working in an environment without pip):


### PR DESCRIPTION
## Summary
- document Python packages needed for running the tests
- reference `environment-dev.yml` as ready-made environment
- mention ENVIRONMENT_SETUP doc in README for running tests

## Testing
- `pre-commit run --files ENVIRONMENT_SETUP.md README.md` *(fails: InvalidManifestError)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68422cc9e3d8832caa79be331c7665ea