### PR TITLE
Fix file cleanup in quant tests

### DIFF
--- a/tests/unit/test_unit_quantify.py
+++ b/tests/unit/test_unit_quantify.py
@@ -430,12 +430,9 @@ chr1	100	.	A	T	60	PASS	.	GT	0/1
                     pytest.skip("_are_alleles_compatible method not found")
 
             finally:
-                # Clean up temp files
-                try:
-                    os.unlink(truth_f.name)
-                    os.unlink(query_f.name)
-                except OSError:
-                    pass
+                # Clean up temp files and surface any errors
+                os.unlink(truth_f.name)
+                os.unlink(query_f.name)
 
     def test_variant_classification(self):
         """Test the _classify_variant_type helper method."""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -340,10 +340,7 @@ def check_file_exists_and_size(file_path: str, min_size: int = 0) -> bool:
     if not os.path.exists(file_path):
         return False
 
-    try:
-        return os.path.getsize(file_path) >= min_size
-    except OSError:
-        return False
+    return os.path.getsize(file_path) >= min_size
 
 
 def cleanup_test_files(output_prefix: str, extensions: List[str]):
@@ -355,8 +352,5 @@ def cleanup_test_files(output_prefix: str, extensions: List[str]):
     """
     for ext in extensions:
         file_path = output_prefix + ext
-        try:
-            if os.path.exists(file_path):
-                os.remove(file_path)
-        except OSError:
-            pass  # Ignore cleanup errors
+        if os.path.exists(file_path):
+            os.remove(file_path)


### PR DESCRIPTION
## Summary
- stop swallowing OSError in `test_unit_quantify.py`
- surface cleanup errors in test utilities

## Testing
- `pytest tests/unit/test_unit_quantify.py::TestQuantifyEngine::test_is_filtered -q` *(fails: Dependency bgzip not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422cd0d650832c885a2607e5819d5a