### PR TITLE
Update installation docs for prerequisites

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -21,6 +21,12 @@ libraries are present. On Debian/Ubuntu systems these can be installed with:
 ```bash
 sudo apt-get install -y build-essential python3-dev cmake zlib1g-dev libbz2-dev libboost-all-dev
 ```
+Install bgzip, tabix, and rtg tools if they are not already present:
+
+```bash
+sudo apt-get install -y tabix
+conda install -c bioconda htslib rtg-tools
+```
 
 ## Creating the Environment
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,22 @@ cd hap.py
 pip install .
 ```
 
+### Prerequisite Tools
+
+The `bgzip` and `tabix` utilities from **htslib** are required for compressing
+and indexing VCF files. When running with `--engine=vcfeval`, the `rtg`
+executable from **rtg-tools** must also be installed.
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install -y tabix
+
+# Conda
+conda install -c bioconda htslib rtg-tools
+```
+
+
+
 This will build all necessary components and install the Python package with
 command-line entry points. For most users, installing via `pip` or with
 `conda env create -f environment.yml` is sufficient. A C++ compiler and Boost

--- a/tests/README.md
+++ b/tests/README.md
@@ -65,6 +65,12 @@ Tests assume that:
 2. C++ components have been built (for tests with the `cpp` marker)
 3. A reference genome is available (either via `HGREF` environment variable or in the example directory)
 4. `bgzip` and `tabix` executables are available in `build/bin` or on the `PATH`. If not, the helper functions in `tests/utils.py` fall back to `pysam` for compression and indexing.
+5. The `rtg` executable must be available when tests use the `vcfeval` engine.
+Install bgzip/tabix and rtg with:
+```bash
+sudo apt-get install -y tabix
+conda install -c bioconda htslib rtg-tools
+```
 
 ### Building the Project Before Running Tests
 


### PR DESCRIPTION
## Summary
- document prerequisite tools and install commands
- mention `bgzip`, `tabix`, and `rtg` in installation docs
- clarify environment and test prerequisites

## Testing
- `pre-commit run --files README.md ENVIRONMENT_SETUP.md tests/README.md` *(fails: InvalidManifestError)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684246a17638832c9496a4fd13f1cd94