### PR TITLE
Handle missing tools gracefully

### DIFF
--- a/src/hap_py/hap.py
+++ b/src/hap_py/hap.py
@@ -192,10 +192,10 @@ def main() -> int:
         "--engine-vcfeval-path",
         dest="engine_vcfeval",
         required=False,
-        default=vcfeval.findVCFEval(),  # Use the function to find rtg
+        default=None,
         help=(
-            'This parameter should give the path to the "rtg" executable. '
-            f"The default is {vcfeval.findVCFEval()}"
+            'Path to the "rtg" executable. If not provided, hap.py will try to '
+            "locate it when vcfeval is run."
         ),
     )
 

--- a/src/hap_py/tools/__init__.py
+++ b/src/hap_py/tools/__init__.py
@@ -87,30 +87,20 @@ def init():
     """
     global GA4GH_TOOLS
 
-    tools_to_check = list(GA4GH_TOOLS)
+    # Only check for bgzip and tabix here. ``rtg`` is checked lazily when the
+    # vcfeval engine is invoked.
+    tools_to_check = [t for t in GA4GH_TOOLS if t != "rtg"]
 
     for x in tools_to_check:
-        if x == "rtg":
-            try:
-                from ..haplo.vcfeval import findVCFEval
-
-                found = findVCFEval()
-            except (ImportError, FileNotFoundError) as e:
-                logging.warning(str(e))
-                if x in GA4GH_TOOLS:
-                    GA4GH_TOOLS.remove(x)
-                continue
-        else:
-            found = which(x)  # Use the 'which' function defined in this file
+        found = which(x)  # Use the 'which' function defined in this file
 
         if not found:
-            if x == "rtg":
-                # Should not happen due to earlier continue, but keep safeguard
-                if x in GA4GH_TOOLS:
-                    GA4GH_TOOLS.remove(x)
-                continue
-
-            raise Exception(f"Dependency {x} not found")
+            logging.warning(
+                "Dependency %s not found - some functionality may be disabled",
+                x,
+            )
+            if x in GA4GH_TOOLS:
+                GA4GH_TOOLS.remove(x)
 
 
 # Call init on import


### PR DESCRIPTION
## Summary
- relax tool initialization errors
- do not search for rtg until vcfeval is used
- clarify --engine-vcfeval-path usage

## Testing
- `pre-commit run --files src/hap_py/tools/__init__.py src/hap_py/hap.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684246a479ac832c96b4c1c69c440d96