### PR TITLE
Add htslib to conda environments

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,6 +11,7 @@ dependencies:
   - scipy
   - bx-python
   - biopython
+  - htslib
   - matplotlib
   - seaborn
   - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - scipy
   - bx-python
   - biopython
+  - htslib
   - rtg-tools
   - pip
   - pip:


### PR DESCRIPTION
## Summary
- make bgzip/tabix available by adding `htslib` to `environment.yml`
- add `htslib` in the development environment file

## Testing
- `pre-commit run --files environment.yml environment-dev.yml` *(fails: InvalidManifestError)*
- `pytest -k 'nothing'` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_684246af1bcc832c90cda4f4711c0d74