### PR TITLE
Add dependency check command and wheel publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,30 +72,28 @@ jobs:
     #   run: |
     #     bash src/sh/run_tests.sh # Or convert these to pytest
 
-    # Optional: Upload artifacts (wheels)
-    # - name: Upload wheel artifact
-    #   uses: actions/upload-artifact@v3
-    #   with:
-    #     name: hap.py-wheel-${{ matrix.os }}-py${{ matrix.python-version }}
-    #     path: dist/*.whl
+    - name: Upload wheel artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: hap.py-wheel-${{ matrix.os }}-py${{ matrix.python-version }}
+        path: dist/*.whl
 
-  # Placeholder for publishing to PyPI - uncomment and configure when ready
-  # publish:
-  #   needs: build_and_test
-  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v3
-  #     with:
-  #       python-version: '3.x' # Use a generic Python version for publishing
-  #   - name: Install build dependencies
-  #     run: pip install setuptools wheel scikit-build twine
-  #   - name: Build sdist and wheel
-  #     run: python -m build --sdist --wheel --outdir dist/ .
-  #   - name: Publish to PyPI
-  #     uses: pypa/gh-action-pypi-publish@release/v1
-  #     with:
-  #       user: __token__
-  #       password: ${{ secrets.PYPI_API_TOKEN }}
+  publish:
+    needs: build_and_test
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install build dependencies
+      run: pip install setuptools wheel scikit-build twine
+    - name: Build sdist and wheel
+      run: python -m build --sdist --wheel --outdir dist/ .
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -371,6 +371,11 @@ command-line entry points. For most users, installing via `pip` or with
 `conda env create -f environment.yml` is sufficient. A C++ compiler and Boost
 are only required when contributing to the Cython extensions.
 
+Prebuilt wheels for Linux and macOS are built on our CI infrastructure and
+published to PyPI for each release. These wheels include the compiled C++
+extensions, so installing with `pip` on a supported platform does not require a
+C++ toolchain.
+
 ### Using Conda
 
 Alternatively, you can create a fully configured conda environment using
@@ -453,6 +458,9 @@ After installation, the `hap.py` command-line tool will be available.
 
 ```bash
 hap.py --help # Show help message
+
+# Verify that external dependencies are available
+hap.py --check-deps
 
 # Example: Compare a VCF file against a truth VCF
 hap.py truth.vcf.gz query.vcf.gz -r reference.fa -o output_prefix

--- a/src/hap_py/hap.py
+++ b/src/hap_py/hap.py
@@ -75,6 +75,14 @@ def main() -> int:
     )
 
     parser.add_argument(
+        "--check-deps",
+        dest="check_deps",
+        action="store_true",
+        default=False,
+        help="Check for required external tools and exit.",
+    )
+
+    parser.add_argument(
         "-r",
         "--reference",
         dest="ref",
@@ -257,6 +265,22 @@ def main() -> int:
     print(f"Hap.py {version}")
     if args.version:
         exit(0)
+
+    if args.check_deps:
+        from .tools import check_dependencies
+
+        deps = check_dependencies()
+        for tool, present in deps.items():
+            status = "found" if present else "missing"
+            print(f"{tool}: {status}")
+            if not present:
+                if tool == "rtg":
+                    print(
+                        "  Install RTG Tools from https://github.com/RealTimeGenomics/rtg-tools"
+                    )
+                else:
+                    print(f"  Install {tool} via your system package manager or conda")
+        return 0
 
     if args.roc:
         args.write_vcf = True

--- a/src/hap_py/tools/__init__.py
+++ b/src/hap_py/tools/__init__.py
@@ -79,6 +79,23 @@ def which(program: str) -> Optional[str]:
 GA4GH_TOOLS = ["bgzip", "tabix", "rtg"]
 
 
+def check_dependencies() -> dict:
+    """Return a mapping of external tools and whether they are available."""
+    results = {}
+    for tool in GA4GH_TOOLS:
+        if tool == "rtg":
+            try:
+                from ..haplo.vcfeval import findVCFEval
+
+                findVCFEval()
+                results[tool] = True
+            except Exception:
+                results[tool] = False
+        else:
+            results[tool] = which(tool) is not None
+    return results
+
+
 def init():
     """
     Checks for external tool dependencies.

--- a/tests/test_cli_source.py
+++ b/tests/test_cli_source.py
@@ -85,6 +85,8 @@ def run_all_tests():
             script_dir / "hap.py", ["--invalid-option"], expected_exit_code=1
         ):
             success = False
+        if not test_cli_script(script_dir / "hap.py", ["--check-deps"]):
+            success = False
 
     return success
 

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -51,6 +51,10 @@ def run_all_tests():
         if not test_cli_tool(command, ["--version"]):
             success = False
 
+    # Check dependency reporting
+    if not test_cli_tool("hap.py", ["--check-deps"]):
+        success = False
+
     # Test with invalid arguments (should fail with non-zero exit code)
     if not test_cli_tool("hap.py", ["--invalid-option"], expected_exit_code=1):
         success = False


### PR DESCRIPTION
## Summary
- add `--check-deps` option to quickly verify external tools
- build and publish wheels on CI
- document wheel availability and dependency checks
- test `--check-deps` in CLI tests

## Testing
- `pre-commit run --files src/hap_py/hap.py src/hap_py/tools/__init__.py README.md .github/workflows/ci.yml tests/test_cli_tools.py tests/test_cli_source.py` *(fails: InvalidManifestError)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684246b8b79c832ca283be59a7ac5a97