### PR TITLE
Enhance RTG lookup for integration tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -65,6 +65,9 @@ Tests assume that:
 2. C++ components have been built (for tests with the `cpp` marker)
 3. A reference genome is available (either via `HGREF` environment variable or in the example directory)
 4. `bgzip` and `tabix` executables are available in `build/bin` or on the `PATH`. If not, the helper functions in `tests/utils.py` fall back to `pysam` for compression and indexing.
+5. The `rtg` executable from RTG Tools is available. Set the `RTG` or
+   `RTGTOOLS_PATH` environment variable to its location if it is not on
+   your `PATH`.
 
 ### Building the Project Before Running Tests
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,9 +48,14 @@ def get_rtg_path():
     """Get the RTG tools path for integration tests."""
     project_root = Path(__file__).parent.parent
 
-    # Check environment variable first
-    if "RTG_PATH" in os.environ and Path(os.environ["RTG_PATH"]).exists():
-        return os.environ["RTG_PATH"]
+    # Check common environment variables first
+    for var in ["RTG", "RTGTOOLS_PATH", "RTG_PATH"]:
+        if var in os.environ:
+            candidate = Path(os.environ[var])
+            if candidate.is_dir():
+                candidate = candidate / "rtg"
+            if candidate.exists():
+                return str(candidate)
 
     # Try external directory (modernized location)
     rtg_path = project_root / "external" / "rtg-tools-3.12.1" / "rtg"
@@ -81,7 +86,13 @@ def get_rtg_path():
 @pytest.fixture(scope="session")
 def rtg_executable():
     """Provide RTG executable path for tests."""
-    return get_rtg_path()
+    rtg = get_rtg_path()
+    # If we resolved to plain "rtg" ensure it exists in PATH
+    if rtg == "rtg" and shutil.which("rtg") is None:
+        pytest.skip(
+            "RTG tools not found. Set RTG or RTGTOOLS_PATH to run integration tests"
+        )
+    return rtg
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary
- search for `RTG` or `RTGTOOLS_PATH` variables when locating RTG Tools
- skip integration tests when RTG can't be found
- document RTG requirement in integration test README

## Testing
- `pre-commit run --files tests/conftest.py tests/README.md`
- `pytest -k faulty_variant_handling tests/integration/test_faulty_variants.py -vv`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684246ddf5b8832cb1d799db67e5de02