### PR TITLE
Improve GA4GH test fixtures

### DIFF
--- a/tests/integration/test_leftshift.py
+++ b/tests/integration/test_leftshift.py
@@ -7,13 +7,11 @@ import filecmp
 import gzip
 import os
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from utils import get_project_root, get_bin_dir
+from tests.utils import get_project_root, get_bin_dir
 
 
 @pytest.mark.integration

--- a/tests/test_qfy_integration.py
+++ b/tests/test_qfy_integration.py
@@ -15,9 +15,10 @@ def test_qfy_basic(tmp_path):
     """Test basic qfy.py functionality with a GA4GH VCF file."""
     # Create a mock GA4GH VCF with expected fields
     ga4gh_vcf = tmp_path / "ga4gh.vcf"
-    with open(ga4gh_vcf, "w") as f:
+    with open(ga4gh_vcf, "w", encoding="utf-8") as f:
         f.write(
             """##fileformat=VCFv4.2
+##INFO=<ID=BS,Number=1,Type=Integer,Description="Benchmarking superlocus ID">
 ##INFO=<ID=Regions,Number=.,Type=String,Description="Regions">
 ##INFO=<ID=Subtype,Number=1,Type=String,Description="Variant subtype">
 ##INFO=<ID=Type,Number=1,Type=String,Description="Variant type">
@@ -25,12 +26,18 @@ def test_qfy_basic(tmp_path):
 ##INFO=<ID=FP,Number=0,Type=Flag,Description="False positive">
 ##INFO=<ID=FN,Number=0,Type=Flag,Description="False negative">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=BD,Number=1,Type=String,Description="Decision">
+##FORMAT=<ID=BK,Number=1,Type=String,Description="Decision subtype">
+##FORMAT=<ID=BI,Number=1,Type=String,Description="Additional info">
+##FORMAT=<ID=QQ,Number=1,Type=Float,Description="Quality">
+##FORMAT=<ID=BVT,Number=1,Type=String,Description="Variant type">
+##FORMAT=<ID=BLT,Number=1,Type=String,Description="Location type">
 ##contig=<ID=chr1,length=248956422>
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TRUTH	QUERY
-chr1	100	.	A	T	.	PASS	Type=SNP;Subtype=SNP;TP	GT	0/1	0/1
-chr1	200	.	G	C	.	PASS	Type=SNP;Subtype=SNP;TP	GT	1/1	0/1
-chr1	300	.	C	G	.	PASS	Type=SNP;Subtype=SNP;FN	GT	0/1	./.
-chr1	400	.	T	A	.	PASS	Type=SNP;Subtype=SNP;FP	GT	./.	0/1
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tTRUTH\tQUERY
+chr1\t100\t.\tA\tT\t50\tPASS\tBS=1;Type=SNP;Subtype=SNP;TP\tGT:BD:BK:BI:QQ:BVT:BLT\t0/1:TP:gm:tv:100:SNP:het\t0/1:TP:gm:tv:100:SNP:het
+chr1\t200\t.\tG\tC\t50\tPASS\tBS=2;Type=SNP;Subtype=SNP;TP\tGT:BD:BK:BI:QQ:BVT:BLT\t1/1:TP:gm:tv:100:SNP:homalt\t0/1:TP:gm:tv:90:SNP:het
+chr1\t300\t.\tC\tG\t50\tPASS\tBS=3;Type=SNP;Subtype=SNP;FN\tGT:BD:BK:BI:QQ:BVT:BLT\t0/1:FN:gm:tv:80:SNP:het\t./.:.:.:.:.:.:.
+chr1\t400\t.\tT\tA\t50\tPASS\tBS=4;Type=SNP;Subtype=SNP;FP\tGT:BD:BK:BI:QQ:BVT:BLT\t./.:.:.:.:.:.:.\t0/1:FP:gm:tv:70:SNP:het
 """
         )
 
@@ -53,6 +60,8 @@ chr1	400	.	T	A	.	PASS	Type=SNP;Subtype=SNP;FP	GT	./.	0/1
         str(ga4gh_vcf),
         "-o",
         output_prefix,
+        "-t",
+        "ga4gh",
     ]
 
     result = subprocess.run(cmd, env=env, capture_output=True, text=True)
@@ -75,9 +84,10 @@ def test_qfy_roc(tmp_path):
     """Test qfy.py ROC functionality."""
     # Create a mock GA4GH VCF with QQ scores for ROC
     ga4gh_vcf = tmp_path / "ga4gh_roc.vcf"
-    with open(ga4gh_vcf, "w") as f:
+    with open(ga4gh_vcf, "w", encoding="utf-8") as f:
         f.write(
             """##fileformat=VCFv4.2
+##INFO=<ID=BS,Number=1,Type=Integer,Description="Benchmarking superlocus ID">
 ##INFO=<ID=Regions,Number=.,Type=String,Description="Regions">
 ##INFO=<ID=Subtype,Number=1,Type=String,Description="Variant subtype">
 ##INFO=<ID=Type,Number=1,Type=String,Description="Variant type">
@@ -86,13 +96,19 @@ def test_qfy_roc(tmp_path):
 ##INFO=<ID=FN,Number=0,Type=Flag,Description="False negative">
 ##INFO=<ID=QQ,Number=1,Type=Float,Description="Quality score for ROC">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=BD,Number=1,Type=String,Description="Decision">
+##FORMAT=<ID=BK,Number=1,Type=String,Description="Decision subtype">
+##FORMAT=<ID=BI,Number=1,Type=String,Description="Additional info">
+##FORMAT=<ID=QQ,Number=1,Type=Float,Description="Quality">
+##FORMAT=<ID=BVT,Number=1,Type=String,Description="Variant type">
+##FORMAT=<ID=BLT,Number=1,Type=String,Description="Location type">
 ##contig=<ID=chr1,length=248956422>
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TRUTH	QUERY
-chr1	100	.	A	T	.	PASS	Type=SNP;Subtype=SNP;TP;QQ=100	GT	0/1	0/1
-chr1	200	.	G	C	.	PASS	Type=SNP;Subtype=SNP;TP;QQ=90	GT	1/1	0/1
-chr1	300	.	C	G	.	PASS	Type=SNP;Subtype=SNP;FN;QQ=80	GT	0/1	./.
-chr1	400	.	T	A	.	PASS	Type=SNP;Subtype=SNP;FP;QQ=70	GT	./.	0/1
-chr1	500	.	G	T	.	PASS	Type=SNP;Subtype=SNP;FP;QQ=50	GT	./.	0/1
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tTRUTH\tQUERY
+chr1\t100\t.\tA\tT\t50\tPASS\tBS=1;Type=SNP;Subtype=SNP;TP;QQ=100\tGT:BD:BK:BI:QQ:BVT:BLT\t0/1:TP:gm:tv:100:SNP:het\t0/1:TP:gm:tv:100:SNP:het
+chr1\t200\t.\tG\tC\t50\tPASS\tBS=2;Type=SNP;Subtype=SNP;TP;QQ=90\tGT:BD:BK:BI:QQ:BVT:BLT\t1/1:TP:gm:tv:100:SNP:homalt\t0/1:TP:gm:tv:90:SNP:het
+chr1\t300\t.\tC\tG\t50\tPASS\tBS=3;Type=SNP;Subtype=SNP;FN;QQ=80\tGT:BD:BK:BI:QQ:BVT:BLT\t0/1:FN:gm:tv:80:SNP:het\t./.:.:.:.:.:.:.
+chr1\t400\t.\tT\tA\t50\tPASS\tBS=4;Type=SNP;Subtype=SNP;FP;QQ=70\tGT:BD:BK:BI:QQ:BVT:BLT\t./.:.:.:.:.:.:.\t0/1:FP:gm:tv:70:SNP:het
+chr1\t500\t.\tG\tT\t50\tPASS\tBS=5;Type=SNP;Subtype=SNP;FP;QQ=50\tGT:BD:BK:BI:QQ:BVT:BLT\t./.:.:.:.:.:.:.\t0/1:FP:gm:tv:50:SNP:het
 """
         )
 
@@ -115,6 +131,8 @@ chr1	500	.	G	T	.	PASS	Type=SNP;Subtype=SNP;FP;QQ=50	GT	./.	0/1
         str(ga4gh_vcf),
         "-o",
         output_prefix,
+        "-t",
+        "ga4gh",
         "--roc",
         "QQ",  # Use QQ field for ROC curve
     ]

--- a/tests/unit/test_ga4gh_validation.py
+++ b/tests/unit/test_ga4gh_validation.py
@@ -1,12 +1,9 @@
 import os
-import sys
 import tempfile
 from pathlib import Path
 
 import pytest
 
-project_root_path = Path(__file__).resolve().parent.parent.parent
-sys.path.insert(0, str(project_root_path / "src"))
 
 # Ensure dummy executables for bgzip and tabix so tools.init() succeeds
 tmp_tool_dir = tempfile.mkdtemp()

--- a/tests/unit/test_pre.py
+++ b/tests/unit/test_pre.py
@@ -1,11 +1,5 @@
 import os
-import sys
 import tempfile
-
-# Add the src directory to the path
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src"))
-)
 
 import hap_py.pre as pre
 from hap_py.tools.vcfextract import extractHeadersJSON

--- a/tests/unit/test_python_hapcmp.py
+++ b/tests/unit/test_python_hapcmp.py
@@ -6,12 +6,8 @@ This module tests the functionality of python_hapcmp.py to ensure
 it correctly performs haplotype comparison.
 """
 
-import sys  # Moved to top
-from pathlib import Path  # Moved to top
-
-# Add src to sys.path to allow importing hap_py
-project_root_path = Path(__file__).resolve().parent.parent.parent
-sys.path.insert(0, str(project_root_path / "src"))
+import sys
+from pathlib import Path
 
 import os
 import tempfile

--- a/tests/unit/test_quantify_models.py
+++ b/tests/unit/test_quantify_models.py
@@ -1,11 +1,7 @@
-import sys
 from pathlib import Path
 
 import pytest
 
-# Ensure hap_py package can be imported from src directory
-project_root_path = Path(__file__).resolve().parent.parent.parent
-sys.path.insert(0, str(project_root_path / "src"))
 
 from hap_py.haplo.quantify_models import StratificationRegion
 

--- a/tests/unit/test_sequence_utils.py
+++ b/tests/unit/test_sequence_utils.py
@@ -7,15 +7,11 @@ it correctly performs sequence manipulations.
 """
 
 import os
-import sys
 import tempfile
 from pathlib import Path
 
 import pytest
 
-# Add src to sys.path to allow importing hap_py
-project_root_path = Path(__file__).resolve().parent.parent.parent
-sys.path.insert(0, str(project_root_path / "src"))
 
 from hap_py.haplo.sequence_utils import FastaReader, SequenceUtils
 

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -3,16 +3,6 @@ Unit tests for hap.py Tools module.
 """
 
 import os
-import sys
-
-# Add src to path for imports during tests
-sys.path.insert(
-    0,
-    os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
-        "src",
-    ),
-)
 
 import hap_py.tools as Tools
 

--- a/tests/unit/test_unit_quantify.py
+++ b/tests/unit/test_unit_quantify.py
@@ -8,16 +8,12 @@ it correctly quantifies variant calls in VCF files.
 
 import json
 import os
-import sys
 import tempfile
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
-# Add src to sys.path to allow importing hap_py
-project_root_path = Path(__file__).resolve().parent.parent.parent
-sys.path.insert(0, str(project_root_path / "src"))
 
 from hap_py.haplo.python_quantify import QuantifyEngine
 

--- a/tests/unit/test_vcfcheck.py
+++ b/tests/unit/test_vcfcheck.py
@@ -7,15 +7,11 @@ it correctly validates VCF files.
 """
 
 import os
-import sys
 import tempfile
 from pathlib import Path
 
 import pytest
 
-# Add src to sys.path to allow importing hap_py
-project_root_path = Path(__file__).resolve().parent.parent.parent
-sys.path.insert(0, str(project_root_path / "src"))
 
 from hap_py.haplo.python_vcfcheck import VCFChecker
 

--- a/tests/unit/test_vcfeval.py
+++ b/tests/unit/test_vcfeval.py
@@ -5,19 +5,11 @@ Unit tests for the Haplo.vcfeval module.
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
-sys.path.insert(
-    0,
-    os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
-        "src",
-    ),
-)
 
 from hap_py.haplo import vcfeval
 

--- a/tests/unit/test_vcfextract.py
+++ b/tests/unit/test_vcfextract.py
@@ -1,12 +1,8 @@
 import json
 import os
-import sys
 import tempfile
 from pathlib import Path
 
-# Add src to sys.path to allow importing hap_py
-project_root_path = Path(__file__).resolve().parent.parent.parent
-sys.path.insert(0, str(project_root_path / "src"))
 
 from hap_py.tools.vcfextract import extract_header, extractHeadersJSON
 


### PR DESCRIPTION
## Summary
- add GA4GH INFO/FORMAT fields to qfy integration test VCFs
- pass `-t ga4gh` to qfy integration tests
- clean up path handling in leftshift and unit tests

## Testing
- `pre-commit run --files tests/integration/test_leftshift.py tests/test_qfy_integration.py tests/unit/test_ga4gh_validation.py tests/unit/test_pre.py tests/unit/test_python_hapcmp.py tests/unit/test_quantify_models.py tests/unit/test_sequence_utils.py tests/unit/test_tools.py tests/unit/test_unit_quantify.py tests/unit/test_vcfcheck.py tests/unit/test_vcfeval.py tests/unit/test_vcfextract.py` *(fails: InvalidManifestError)*
- `pytest -k ga4gh_validation -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684246e20664832c9467b733d02d6182