### PR TITLE
Fix ci-alpha help percent escaping

### DIFF
--- a/src/hap_py/qfy.py
+++ b/src/hap_py/qfy.py
@@ -389,7 +389,7 @@ def updateArgs(parser: argparse.ArgumentParser) -> None:
         type=float,
         help="Confidence level for Jeffrey's CI for recall, precision and fraction of non-assessed calls. "
         "Enhanced ROC analysis uses bootstrap sampling to calculate confidence intervals when > 0. "
-        "Common values: 0.05 (95% CI), 0.1 (90% CI). Set to 0 to disable confidence intervals.",
+        "Common values: 0.05 (95%% CI), 0.1 (90%% CI). Set to 0 to disable confidence intervals.",
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Summary
- fix argparse help string for `--ci-alpha`

## Testing
- `build/bin/hap.py --help`
- `build/bin/quantify --help`
- `pytest tests/test_cli_source.py -q` *(fails: fixture 'script_path' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fc0a5300832ca047cddf4ec8c11e