### PR TITLE
Ensure RTG tools available in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
         # Install build dependencies explicitly
         pip install setuptools wheel scikit-build cmake "cython>=0.29.24" "numpy>=1.19.0" toml build
 
+    - name: Add RTG tools to PATH
+      run: |
+        echo "RTGTOOLS_PATH=${{ github.workspace }}/rtg-core-3.13/rtg" >> $GITHUB_ENV
+        echo "${{ github.workspace }}/rtg-core-3.13" >> $GITHUB_PATH
+
     - name: Build and install
       run: |
         # Build wheel with pip

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -46,6 +46,11 @@ jobs:
       run: |
         pip install -e .[dev] # Installs hap.py in development mode with test dependencies
 
+    - name: Add RTG tools to PATH
+      run: |
+        echo "RTGTOOLS_PATH=${{ github.workspace }}/rtg-core-3.13/rtg" >> $GITHUB_ENV
+        echo "${{ github.workspace }}/rtg-core-3.13" >> $GITHUB_PATH
+
     - name: Lint with Black
       run: |
         pip install black

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -11,7 +11,7 @@ Create and activate a `happy-dev` environment with **conda** or **mamba** for ha
 - **Python Location**: `$CONDA_PREFIX/bin/python`
 - **Package Installation**: Normal install in site-packages
 - **Testing Framework**: pytest 8.3.5
-- **RTG Tools**: Use the `rtg` executable installed in the `happy-dev` conda environment. After activating the environment, run `which rtg` to confirm its location.
+- **RTG Tools**: Use the `rtg` executable installed in the `happy-dev` conda environment. After activating the environment, run `which rtg` to confirm its location. The test suite requires this executable to be available on your `$PATH` or provided via the `RTGTOOLS_PATH` environment variable.
 
 ## System Dependencies
 


### PR DESCRIPTION
## Summary
- add RTG tools path setup in CI workflows
- mention RTG path requirement in environment guide

## Testing
- `pytest -q` *(fails: CalledProcessError, ModuleNotFoundError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6842fc0d2020832c925eed522edf2ee4