### PR TITLE
Fix ruff warnings in tests

### DIFF
--- a/tests/integration/test_gvcf_homref.py
+++ b/tests/integration/test_gvcf_homref.py
@@ -52,8 +52,8 @@ def test_gvcf_homref(tmp_path):
 
     # Ensure the output VCF was created and contains data.
     assert output_vcf.exists(), "multimerge did not produce an output VCF"
-    with open(output_vcf, "r", encoding="utf-8") as f:
-        lines = [l for l in f.readlines() if not l.startswith("#")]
+    with open(output_vcf, encoding="utf-8") as f:
+        lines = [line for line in f.readlines() if not line.startswith("#")]
     assert lines, "multimerge output VCF is empty"
 
 
@@ -91,6 +91,6 @@ def test_gvcf_homref_with_variants(tmp_path):
 
     # Ensure output file has variant entries.
     assert output_vcf.exists(), "multimerge did not produce an output VCF"
-    with open(output_vcf, "r", encoding="utf-8") as f:
-        lines = [l for l in f.readlines() if not l.startswith("#")]
+    with open(output_vcf, encoding="utf-8") as f:
+        lines = [line for line in f.readlines() if not line.startswith("#")]
     assert lines, "multimerge output VCF is empty"

--- a/tests/integration/test_leftshift.py
+++ b/tests/integration/test_leftshift.py
@@ -7,11 +7,12 @@ import filecmp
 import gzip
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
-from tests.utils import get_project_root, get_bin_dir
+from tests.utils import get_bin_dir, get_project_root
 
 
 @pytest.mark.integration

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,9 +84,7 @@ def get_libexec_dir() -> Path:
 # Check for required external dependencies
 def check_external_dependencies():
     """Check if required external dependencies are available."""
-    project_root = get_project_root()
-
-
+    get_project_root()
 
     # Check for other required tools
     required_tools = ["bcftools", "samtools", "pysam"]


### PR DESCRIPTION
## Summary
- update variable names in GVCF homref integration test
- add missing import in leftshift test
- drop unused variable from `check_external_dependencies`

## Testing
- `ruff tests/integration/test_gvcf_homref.py tests/integration/test_leftshift.py tests/test_utils.py`
- `pytest -k 'gvcf_homref or leftshift or utils'` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684305612554832ca1f19261a26ef3da