### PR TITLE
Fix test import for fastasize

### DIFF
--- a/tests/integration/test_fastasize.py
+++ b/tests/integration/test_fastasize.py
@@ -21,7 +21,7 @@ def setup_path():
 def test_fastasize_calculation():
     """Test fastasize's calculateLength function"""
     # Import the function after the path has been set up
-    from tools.fastasize import calculateLength
+    from hap_py.tools.fastasize import calculateLength
 
     # Test with the same parameters as in the original script
     locations = "chrMT chrY:1-10"


### PR DESCRIPTION
## Summary
- update `test_fastasize` to import the calculateLength utility from the installed hap_py package

## Testing
- `pytest tests/integration/test_fastasize.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6843082a7894832c9c0e23a59bac7b56