### PR TITLE
Install bcftools in dev env and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake build-essential zlib1g-dev libbz2-dev liblzma-dev libcurl4-openssl-dev
+        sudo apt-get install -y cmake build-essential zlib1g-dev libbz2-dev liblzma-dev libcurl4-openssl-dev bcftools
 
     - name: Install system dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install cmake zlib bzip2 xz curl
+        brew install cmake zlib bzip2 xz curl bcftools
 
     - name: Install Python build dependencies
       run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -27,12 +27,12 @@ jobs:
       if: runner.os == \'Linux\'
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake zlib1g-dev libbz2-dev liblzma-dev libcurl4-openssl-dev
+        sudo apt-get install -y build-essential cmake zlib1g-dev libbz2-dev liblzma-dev libcurl4-openssl-dev bcftools
 
     - name: Install system dependencies (macOS)
       if: runner.os == \'macOS\'
       run: |
-        brew install cmake zlib bzip2 xz curl
+        brew install cmake zlib bzip2 xz curl bcftools
 
     # Windows dependencies might need Chocolatey or similar, or might be covered by scikit-build\'s CMake.
     # For now, assuming CMake and standard compilers are available on windows-latest.

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -21,11 +21,11 @@ libraries are present. On Debian/Ubuntu systems these can be installed with:
 ```bash
 sudo apt-get install -y build-essential python3-dev cmake zlib1g-dev libbz2-dev libboost-all-dev
 ```
-Install bgzip, tabix, and rtg tools if they are not already present:
+Install bgzip, tabix, bcftools, and rtg tools if they are not already present:
 
 ```bash
 sudo apt-get install -y tabix
-conda install -c bioconda htslib rtg-tools
+conda install -c bioconda htslib bcftools rtg-tools
 ```
 
 ## Creating the Environment

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,6 +13,7 @@ dependencies:
   - bx-python
   - biopython
   - htslib
+  - bcftools
   - matplotlib
   - seaborn
   - scikit-learn


### PR DESCRIPTION
## Summary
- install `bcftools` in `environment-dev.yml`
- install `bcftools` in CI workflows
- document `bcftools` in environment setup instructions

## Testing
- `pytest tests/integration/test_integration.py::test_integration -vv` *(fails: multimerge unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68430834d900832cba246fcc8c3a6d89