### PR TITLE
Add pytest-benchmark to dev environment

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -18,6 +18,7 @@ dependencies:
   - scikit-learn
   - pytest
   - pytest-cov
+  - pytest-benchmark
   - nose
   - pip
   - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ cpp = [
 dev = [
     "pytest>=6.0.1",
     "pytest-cov>=2.10.0",
+    "pytest-benchmark>=3.4.1",
     "nose>=1.3.7",
     "black>=23.3.0",
     "ruff>=0.11.11",


### PR DESCRIPTION
## Summary
- add `pytest-benchmark` to pyproject optional dev dependencies
- include `pytest-benchmark` in conda dev environment file

## Testing
- `pytest -k unit -q` *(fails: FileNotFoundError for rtg executable, missing example VCF)*

------
https://chatgpt.com/codex/tasks/task_e_6843083813f8832c8d3d72e0d2d728ba