### PR TITLE
Improve version flag handling

### DIFF
--- a/src/hap_py/pre.py
+++ b/src/hap_py/pre.py
@@ -482,6 +482,11 @@ def main() -> int:
     Returns:
         int: 0 on success, non-zero on failure
     """
+    if "--version" in sys.argv or "-v" in sys.argv:
+        from .tools.version import version
+        print(f"pre.py {version}")
+        return 0
+
     parser = argparse.ArgumentParser("VCF preprocessor")
 
     # input
@@ -579,9 +584,6 @@ def main() -> int:
         parser.print_help()
         exit(0)
 
-    if args.version:
-        print(f"pre.py {version}")
-        exit(0)
 
     args.input = args.input[0]
     args.output = args.output[0]

--- a/src/hap_py/qfy.py
+++ b/src/hap_py/qfy.py
@@ -408,6 +408,11 @@ def main() -> int:
     Returns:
         int: 0 on success, non-zero on failure
     """
+    if "--version" in sys.argv or "-v" in sys.argv:
+        from .tools.version import version
+        print(f"qfy.py {version}")
+        return 0
+
     parser = argparse.ArgumentParser("Quantify annotated VCFs")
 
     parser.add_argument(
@@ -530,9 +535,6 @@ def main() -> int:
         parser.print_help()
         exit(0)
 
-    if args.version:
-        print(f"qfy.py {version}")
-        exit(0)
 
     if args.fp_bedfile and args.preprocessing_truth_confregions:
         conf_temp = gvcf2bed.gvcf2bed(


### PR DESCRIPTION
## Summary
- check for `--version` before parsing args in `pre.py` and `qfy.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'Bio')*

------
https://chatgpt.com/codex/tasks/task_e_684314fc89e0832ca3a6600dfd1d0b7d