### PR TITLE
Enable direct script execution for hap_py

### DIFF
--- a/src/hap_py/hap.py
+++ b/src/hap_py/hap.py
@@ -34,6 +34,10 @@ import time
 import traceback
 from pathlib import Path
 
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    __package__ = "hap_py"
+
 # Modern imports using the new package structure
 try:
     # When run as module

--- a/src/hap_py/pre.py
+++ b/src/hap_py/pre.py
@@ -31,6 +31,11 @@ import tempfile
 import time
 import traceback
 from typing import List, Optional, Union
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    __package__ = "hap_py"
 
 scriptDir = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 # Update path for Python 3

--- a/src/hap_py/qfy.py
+++ b/src/hap_py/qfy.py
@@ -36,6 +36,10 @@ from pathlib import Path
 
 import pandas as pd
 
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    __package__ = "hap_py"
+
 # Modern imports using the new package structure
 try:
     # When run as module


### PR DESCRIPTION
## Summary
- ensure hap.py can be executed directly by adjusting `__package__`
- apply the same logic to `pre.py` and `qfy.py`

## Testing
- `python src/hap_py/hap.py --version`
- `pytest tests/test_cli_tools.py::test_cli_tool_version -vv` *(fails: preprocessor and quantify require extra args)*

------
https://chatgpt.com/codex/tasks/task_e_68431510878c832c998c1d98bf445084