### PR TITLE
Allow Python 3 in detect_vars

### DIFF
--- a/src/sh/detect_vars.sh
+++ b/src/sh/detect_vars.sh
@@ -51,14 +51,18 @@ fi
 export PYTHON=${PYTHON:-python}
 
 PYVERSION=$(${PYTHON} --version 2>&1)
-if [[ "$PYVERSION" != "Python 2.7."* ]] && [[ $DEFAULT_PYTHON == 1 ]]; then
-	PYTHON=python2.7
+PYMAJOR=$(${PYTHON} -c 'import sys; print(sys.version_info[0])' 2>/dev/null)
+PYMINOR=$(${PYTHON} -c 'import sys; print(sys.version_info[1])' 2>/dev/null)
+
+if [[ $DEFAULT_PYTHON == 1 ]] && [[ "$PYMAJOR" != "2" && "$PYMAJOR" != "3" ]]; then
+    PYTHON=python2.7
+    PYVERSION=$(${PYTHON} --version 2>&1)
+    PYMAJOR=$(${PYTHON} -c 'import sys; print(sys.version_info[0])' 2>/dev/null)
+    PYMINOR=$(${PYTHON} -c 'import sys; print(sys.version_info[1])' 2>/dev/null)
 fi
 
-PYVERSION=$(${PYTHON} --version 2>&1)
-if [[ "$PYVERSION" != "Python 2.7."* ]]; then
-    echo "Hap.py requires Python 2.7.x. $PYTHON is $PYVERSION"
-    exit 1
+if [[ "$PYMAJOR" == "2" && "$PYMINOR" != "7" ]] || [[ "$PYMAJOR" != "2" && "$PYMAJOR" != "3" ]]; then
+    echo "Warning: Hap.py is tested with Python 2.7 or 3.x. $PYTHON is $PYVERSION" >&2
 fi
 
 export HCVERSION=`${PYTHON} ${HCDIR}/hap.py --version`


### PR DESCRIPTION
## Summary
- relax Python detection in `src/sh/detect_vars.sh`
- warn when Python isn't 2.7 or 3.x rather than exiting

## Testing
- `bash -n src/sh/detect_vars.sh`

------
https://chatgpt.com/codex/tasks/task_e_68431d0eda9c832ca139ff23b34031e6