### PR TITLE
Skip tests without bcftools/bgzip/tabix

### DIFF
--- a/tests/integration/test_blocksplit.py
+++ b/tests/integration/test_blocksplit.py
@@ -9,27 +9,36 @@ from pathlib import Path
 
 import pytest
 
+from tests.utils import (
+    get_bin_dir,
+    get_project_root,
+    require_tools,
+)
+
 
 @pytest.mark.integration
 @pytest.mark.cpp
 def test_blocksplit():
     """Test blocksplit functionality on VCF files."""
     # Get paths to required files
-    project_root = Path(__file__).parent.parent.parent
+    project_root = get_project_root()
     example_dir = project_root / "example" / "happy"
     vcf1_path = example_dir / "PG_NA12878_hg38-chr21.vcf.gz"
     vcf2_path = example_dir / "NA12878-GATK3-chr21.vcf.gz"
 
     # Get path to tools
-    bin_dir = project_root / "build" / "bin"
+    bin_dir = get_bin_dir()
     blocksplit_bin = bin_dir / "blocksplit"
     bcftools_bin = bin_dir / "bcftools"
+
+    # Skip if required external tool is missing
+    require_tools("bcftools")
 
     # Check that required files exist
     assert vcf1_path.exists(), f"Test VCF1 {vcf1_path} not found"
     assert vcf2_path.exists(), f"Test VCF2 {vcf2_path} not found"
-    assert blocksplit_bin.exists(), f"Blocksplit binary {blocksplit_bin} not found"
-    assert bcftools_bin.exists(), f"Bcftools binary {bcftools_bin} not found"
+    if not blocksplit_bin.exists():
+        pytest.skip(f"blocksplit binary not found at {blocksplit_bin}")
 
     # Create temporary files
     with tempfile.NamedTemporaryFile(suffix=".bed") as temp_result:

--- a/tests/integration/test_happy_pg.py
+++ b/tests/integration/test_happy_pg.py
@@ -11,6 +11,7 @@ from tests.utils import (
     get_bin_dir,
     get_example_dir,
     get_python_executable,
+    require_tools,
     run_shell_command,
 )
 
@@ -23,6 +24,9 @@ def test_happy_pg_test(tmp_path):
     bin_dir = get_bin_dir()
     example_dir = get_example_dir()
     python_exe = get_python_executable()
+
+    # Skip if required external tools are missing
+    require_tools("bcftools", "bgzip", "tabix")
 
     # Prepare file paths
     reference_fa = example_dir / "chr21.fa"

--- a/tests/integration/test_multimerge.py
+++ b/tests/integration/test_multimerge.py
@@ -8,7 +8,12 @@ import subprocess
 
 import pytest
 
-from tests.utils import get_bin_dir, get_project_root, run_command
+from tests.utils import (
+    get_bin_dir,
+    get_project_root,
+    require_tools,
+    run_command,
+)
 
 
 @pytest.mark.integration
@@ -76,6 +81,9 @@ def test_multimerge_import(tmp_path):
 
     # Define path to multimerge binary
     multimerge_bin = bin_dir / "multimerge"
+
+    # Skip if required external tools are missing
+    require_tools("bgzip", "tabix")
 
     # Skip test if binary doesn't exist
     if not multimerge_bin.exists():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,16 +71,34 @@ def find_reference_file() -> Optional[str]:
 
 
 def check_tool_availability(tool_name: str) -> bool:
-    """Check if a tool is available in the bin directory.
+    """Check if a tool is available.
+
+    The helper first looks for the executable in ``build/bin`` and then
+    falls back to ``shutil.which`` to search the ``PATH``.
 
     Args:
         tool_name: Name of the tool to check
 
     Returns:
-        True if the tool is available, False otherwise
+        ``True`` if the tool is available, ``False`` otherwise
     """
+
     tool_path = get_bin_dir() / tool_name
-    return tool_path.exists()
+    if tool_path.exists() and os.access(tool_path, os.X_OK):
+        return True
+
+    return shutil.which(tool_name) is not None
+
+
+def require_tools(*tool_names: str) -> None:
+    """Skip the current test if any of the specified tools are missing."""
+
+    missing = [t for t in tool_names if not check_tool_availability(t)]
+    if missing:
+        import pytest
+
+        tools = ", ".join(missing)
+        pytest.skip(f"Required tool(s) not available: {tools}")
 
 
 def compare_files(file1: Path, file2: Path, ignore_comments: bool = False) -> bool:


### PR DESCRIPTION
## Summary
- add helpers to detect external tools
- skip integration tests requiring bcftools/bgzip/tabix when tools are absent

## Testing
- `pre-commit run --files tests/utils.py tests/integration/test_blocksplit.py tests/integration/test_happy_pg.py tests/integration/test_multimerge.py` *(fails: InvalidManifestError)*
- `pytest tests/integration/test_blocksplit.py::test_blocksplit -q`
- `pytest tests/integration/test_multimerge.py::test_multimerge_import -q`
- `pytest tests/integration/test_happy_pg.py::test_happy_pg_test -q`

------
https://chatgpt.com/codex/tasks/task_e_6847374e7624832cbcc7155ff96c9862