### PR TITLE
Handle optional bio packages in CI and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
         # Install the wheel and dev dependencies
         pip install dist/*.whl
-        pip install .[dev]
+        pip install .[dev,bio]
 
     - name: Lint with Black and Ruff
       run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install project with dependencies
       run: |
-        pip install -e .[dev] # Installs hap.py in development mode with test dependencies
+        pip install -e .[dev,bio] # Install hap.py with optional bio deps for tests
 
     - name: Add RTG tools to PATH
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,13 +38,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy>=1.19.0",
-    "pandas>=1.0.5",
     "psutil>=5.8.0",
-    "pysam>=0.16.0",
-    "scipy>=1.5.0",
     "bx-python>=0.8.9",
-    "biopython>=1.78",
     "setuptools>=50.3.2",
     "wheel>=0.35.1",
 ]
@@ -64,6 +59,13 @@ dev = [
     "mypy>=1.2.0",
     "pre-commit",
     "tox",
+]
+bio = [
+    "numpy>=1.19.0",
+    "pandas>=1.0.5",
+    "pysam>=0.16.0",
+    "scipy>=1.5.0",
+    "biopython>=1.78",
 ]
 viz = [
     "matplotlib>=3.3.0",

--- a/tests/unit/fixed_test_normalize_variant.py
+++ b/tests/unit/fixed_test_normalize_variant.py
@@ -1,5 +1,8 @@
 import tempfile
 
+import pytest
+
+pytest.importorskip("pysam")
 import pysam
 
 from hap_py.haplo.python_preprocess import PreprocessEngine

--- a/tests/unit/test_python_preprocess.py
+++ b/tests/unit/test_python_preprocess.py
@@ -7,8 +7,10 @@ import os
 import tempfile
 from pathlib import Path
 
-import pysam
 import pytest
+
+pytest.importorskip("pysam")
+import pysam
 
 from hap_py.haplo.python_preprocess import DecomposeLevel, PreprocessEngine
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -388,8 +388,9 @@ def compress_and_index_vcf(vcf_path: Path, output_path: Optional[Path] = None) -
         with open(output_path, "wb") as out_f:
             subprocess.run(bgzip_cmd, check=True, stdout=out_f)
     else:
-        import pysam
+        import pytest
 
+        pysam = pytest.importorskip("pysam")
         pysam.tabix_compress(str(vcf_path), str(output_path), force=True)
 
     tabix_cmd = None
@@ -401,8 +402,9 @@ def compress_and_index_vcf(vcf_path: Path, output_path: Optional[Path] = None) -
     if tabix_cmd:
         subprocess.run(tabix_cmd, check=True)
     else:
-        import pysam
+        import pytest
 
+        pysam = pytest.importorskip("pysam")
         pysam.tabix_index(str(output_path), preset="vcf", force=True)
 
     return output_path


### PR DESCRIPTION
## Summary
- add optional `bio` extra with heavy dependencies
- install `bio` extras in CI workflows
- skip tests when `pysam` isn't installed

## Testing
- `pre-commit run --files pyproject.toml .github/workflows/python-ci.yml .github/workflows/ci.yml tests/unit/test_python_preprocess.py tests/unit/fixed_test_normalize_variant.py tests/utils.py`
- `pytest -q` *(fails: FileNotFoundError: rtg executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_684737501568832c8f8df74ff9507f1f