### PR TITLE
Fix GA4GH validation for BVT/BLT fields

### DIFF
--- a/src/hap_py/haplo/metrics_calculator.py
+++ b/src/hap_py/haplo/metrics_calculator.py
@@ -297,8 +297,18 @@ class MetricsCalculator:
         else:
             metrics["frac_na"] = 0.0
 
-        truth_variants = df[(df.get("TP", False)) | (df.get("FN", False))]
-        query_variants = df[(df.get("TP", False)) | (df.get("FP", False))]
+        tp_mask = df.get("TP")
+        if tp_mask is None:
+            tp_mask = pd.Series(False, index=df.index)
+        fn_mask = df.get("FN")
+        if fn_mask is None:
+            fn_mask = pd.Series(False, index=df.index)
+        fp_mask = df.get("FP")
+        if fp_mask is None:
+            fp_mask = pd.Series(False, index=df.index)
+
+        truth_variants = df[tp_mask.astype(bool) | fn_mask.astype(bool)]
+        query_variants = df[tp_mask.astype(bool) | fp_mask.astype(bool)]
 
         metrics["truth_titv"] = MetricsCalculator._titv_ratio(truth_variants)
         metrics["query_titv"] = MetricsCalculator._titv_ratio(query_variants)

--- a/src/hap_py/haplo/python_quantify.py
+++ b/src/hap_py/haplo/python_quantify.py
@@ -167,8 +167,17 @@ class QuantifyEngine:
         required_info = ["BS"]
         missing_info = [f for f in required_info if f not in header.info]
 
-        required_format = ["GT", "BD", "BK", "BI", "QQ", "BVT", "BLT"]
+        required_format = ["GT", "BD", "BK", "BI", "QQ"]
         missing_format = [f for f in required_format if f not in header.formats]
+
+        # BVT/BLT are optional in the input and will be added if missing
+        optional_format = ["BVT", "BLT"]
+        missing_optional = [f for f in optional_format if f not in header.formats]
+        if missing_optional:
+            logger.debug(
+                "Optional GA4GH fields missing in input VCF: %s",
+                ", ".join(missing_optional),
+            )
 
         required_samples = ["TRUTH", "QUERY"]
         missing_samples = [s for s in required_samples if s not in header.samples]
@@ -606,7 +615,11 @@ class QuantifyEngine:
             out_vcf = pysam.VariantFile(output_path, "w", header=header)
 
             for _, row in df.iterrows():
-                alleles = (row["ref"],) + tuple(row["alt"].split(",")) if row["alt"] else (row["ref"],)
+                alleles = (
+                    (row["ref"],) + tuple(row["alt"].split(","))
+                    if row["alt"]
+                    else (row["ref"],)
+                )
                 rec = out_vcf.new_record(
                     contig=row["chrom"],
                     start=int(row["pos"]) - 1,

--- a/src/hap_py/pre.py
+++ b/src/hap_py/pre.py
@@ -30,8 +30,8 @@ import sys
 import tempfile
 import time
 import traceback
-from typing import List, Optional, Union
 from pathlib import Path
+from typing import List, Optional, Union
 
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -56,7 +56,6 @@ try:
     from .tools import vcfextract
     from .tools.bcftools import preprocessVCF, runBcftools
     from .tools.fastasize import fastaContigLengths
-    from .tools.version import version
 except ImportError:
     # When run directly or as script
     import sys
@@ -68,7 +67,6 @@ except ImportError:
     from tools import vcfextract
     from tools.bcftools import preprocessVCF, runBcftools
     from tools.fastasize import fastaContigLengths
-    from tools.version import version
 
 
 def hasChrPrefix(chrlist: List[str]) -> Optional[bool]:
@@ -489,6 +487,7 @@ def main() -> int:
     """
     if "--version" in sys.argv or "-v" in sys.argv:
         from .tools.version import version
+
         print(f"pre.py {version}")
         return 0
 
@@ -588,7 +587,6 @@ def main() -> int:
             logging.error(f"Unknown arguments specified: {unknown_args}")
         parser.print_help()
         exit(0)
-
 
     args.input = args.input[0]
     args.output = args.output[0]

--- a/tests/integration/test_leftshift.py
+++ b/tests/integration/test_leftshift.py
@@ -6,7 +6,6 @@ Migrated from src/sh/run_leftshift_test.sh
 import filecmp
 import gzip
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -20,7 +19,6 @@ def test_leftshift(tmp_path):
     # Get paths to required files
     project_root = get_project_root()
     src_data_dir = project_root / "src" / "data" / "leftshifting_example"
-    compare_script = project_root / "src" / "sh" / "compare_extended.py"
 
     # Input files
     truth_vcf = src_data_dir / "truth.vcf"
@@ -65,17 +63,11 @@ def test_leftshift(tmp_path):
     assert result.returncode == 0, f"hap.py failed with left-shifting: {result.stderr}"
 
     # Compare extended files
-    compare_cmd = [
-        sys.executable,
-        str(compare_script),
-        str(output_extended),
-        str(expected_extended),
-    ]
+    import pandas as pd
 
-    compare_result = subprocess.run(compare_cmd, capture_output=True, text=True)
-    assert (
-        compare_result.returncode == 0
-    ), f"Extended CSV comparison failed: {compare_result.stderr}"
+    df_actual = pd.read_csv(output_extended)
+    df_expected = pd.read_csv(expected_extended)
+    pd.testing.assert_frame_equal(df_actual, df_expected)
 
     # Compare VCF files - extract non-header lines from the gzipped VCF
     with gzip.open(output_vcf_gz, "rt") as f_gz:

--- a/tests/integration/test_quantify_stratification.py
+++ b/tests/integration/test_quantify_stratification.py
@@ -19,7 +19,6 @@ def test_quantify_stratification(tmp_path):
     project_root = get_project_root()
     example_dir = project_root / "example" / "happy"
     compare_summaries_script = project_root / "src" / "sh" / "compare_summaries.py"
-    compare_extended_script = project_root / "src" / "sh" / "compare_extended.py"
 
     # Input files
     reference = example_dir / "hg38.chr21.fa"
@@ -88,17 +87,8 @@ def test_quantify_stratification(tmp_path):
     )
 
     # Compare extended files
-    compare_extended_cmd = [
-        sys.executable,
-        str(compare_extended_script),
-        str(output_extended),
-        str(expected_extended),
-    ]
+    import pandas as pd
 
-    compare_extended_result = subprocess.run(
-        compare_extended_cmd, capture_output=True, text=True
-    )
-    assert compare_extended_result.returncode == 0, (
-        f"Extended CSV comparison failed: {compare_extended_result.stderr}\n"
-        f"Check diff {output_extended} {expected_extended}"
-    )
+    df_actual = pd.read_csv(output_extended)
+    df_expected = pd.read_csv(expected_extended)
+    pd.testing.assert_frame_equal(df_actual, df_expected)


### PR DESCRIPTION
## Summary
- relax GA4GH VCF validation to treat BVT/BLT as optional
- handle missing TP/FN/FP masks when computing metrics
- compare extended CSVs directly in integration tests
- remove unused import in preprocessing module

## Testing
- `pre-commit run --all-files`
- `pytest tests/unit/test_ga4gh_validation.py::test_ga4gh_validation_success -q`
- `pytest tests/unit/test_ga4gh_validation.py::test_ga4gh_validation_failure -q`
- `pytest tests/integration/test_leftshift.py::test_leftshift -q` *(fails: DataFrame are different)*


------
https://chatgpt.com/codex/tasks/task_e_6849c3e3cf80832cbe0dcc98097007a7