### PR TITLE
Use pysam for compression and indexing

### DIFF
--- a/src/hap_py/haplo/quantify.py
+++ b/src/hap_py/haplo/quantify.py
@@ -18,13 +18,13 @@ import json
 import logging
 import os
 import shlex
-import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
+import pysam
 
 from .metrics_calculator import MetricsCalculator
 
@@ -193,55 +193,20 @@ def _merge_vcfs(vcfs: List[str], outvcf: str) -> None:
         with contextlib.suppress(Exception):
             os.unlink(outvcf)
 
-    cmd_line = ["bcftools", "concat", "-a"]
-    cmd_line.extend(vcfs)
-    cmd_line.extend(["-o", outvcf])
+    # Concatenate VCFs using pysam.  This assumes all VCFs share the same header
+    # which is true for our generated temp files.
+    with pysam.VariantFile(vcfs[0]) as template:
+        with pysam.VariantFile(outvcf, "w", header=template.header) as out:
+            for vcf in vcfs:
+                with pysam.VariantFile(vcf) as f:
+                    for rec in f.fetch():
+                        out.write(rec)
 
-    cmd_line_str = _make_cmdline(cmd_line)
-    logging.info(cmd_line_str)
-
-    try:
-        po = subprocess.Popen(
-            cmd_line_str,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
-        )
-
-        stdout, stderr = po.communicate()
-        return_code = po.returncode
-
-        if return_code != 0:
-            logging.error(f"bcftools concat error: {stderr}")
-            raise Exception(f"Failed to concatenate {str(vcfs)}")
-    except Exception as e:
-        logging.error(f"Command execution failed: {str(e)}")
-        raise Exception(f"Failed to concatenate {str(vcfs)}: {str(e)}")
-
-    # index vcf
-    cmd_line = ["bcftools", "index", outvcf]
-
-    cmd_line_str = _make_cmdline(cmd_line)
-    logging.info(cmd_line_str)
-
-    po = subprocess.Popen(
-        cmd_line_str,
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        universal_newlines=True,
-    )
-
-    stdout, stderr = po.communicate()
-
-    po.wait()
-
-    return_code = po.returncode
-
-    if return_code != 0:
-        logging.error(f"bcftools index error: {stderr}")
-        logging.warning(f"Failed to index {outvcf}")
+    if outvcf.endswith(".gz"):
+        try:
+            pysam.tabix_index(outvcf, preset="vcf", force=True)
+        except Exception as e:
+            logging.warning(f"Failed to index {outvcf}: {e}")
 
 
 def _write_outfiles(

--- a/src/hap_py/tools/__init__.py
+++ b/src/hap_py/tools/__init__.py
@@ -240,41 +240,40 @@ def mkdir_p(path: str) -> None:
 
 
 class BGZipFile:
-    """BGZip file helper"""
+    """BGZip file helper using ``pysam``.
 
-    def __init__(self, filename: str, force: bool = False):
-        """Make a subprocess for bgzip
+    The previous implementation spawned the external ``bgzip`` executable via
+    ``subprocess``.  ``pysam`` provides the same functionality natively, so we
+    use :class:`pysam.BGZFile` instead to remove the dependency on the external
+    tool.
+    """
 
-        Args:
-            filename: name of the output file
-            force: true to overwrite if file exists
+    def __init__(self, filename: str, force: bool = False) -> None:
+        """Create a BGZipFile.
+
+        Parameters
+        ----------
+        filename
+            Name of the output file.
+        force
+            Overwrite existing file if ``True``.
         """
+
         if os.path.exists(filename) and not force:
             raise Exception(f"File {filename} exists, use force=True to overwrite")
 
-        self.write_file = open(filename, "wb")
-        zip_pipe = subprocess.Popen(
-            ["bgzip", "-f"],
-            stdin=subprocess.PIPE,
-            stdout=self.write_file,
-            stderr=subprocess.PIPE,
-            shell=True,
-        )
-        self.zip_pipe = zip_pipe
+        # ``pysam.BGZFile`` handles compression internally
+        self.write_file = pysam.BGZFile(filename, "wb")
         self.name = filename
 
     def close(self) -> None:
-        """Close the file handle and subprocess."""
-        self.zip_pipe.stdin.flush()
-        self.zip_pipe.stdin.close()
-        self.zip_pipe.wait()
+        """Close the file handle."""
         self.write_file.flush()
         self.write_file.close()
 
-    def write(self, *args, **kwargs) -> None:
+    def write(self, *args, **kwargs) -> None:  # type: ignore[override]
         """Write to the BGZipped file."""
         if isinstance(args[0], str):
-            # Convert string to bytes for Python 3
-            self.zip_pipe.stdin.write(args[0].encode("utf-8"))
+            self.write_file.write(args[0].encode("utf-8"))
         else:
-            self.zip_pipe.stdin.write(*args, **kwargs)
+            self.write_file.write(*args, **kwargs)

--- a/src/hap_py/tools/fastasize.py
+++ b/src/hap_py/tools/fastasize.py
@@ -22,13 +22,11 @@
 # Peter Krusche <pkrusche@illumina.com>
 #
 
-import contextlib
 import logging
 import os
-import shlex
-import subprocess
-import tempfile
 from typing import Dict, List
+
+import pysam
 
 
 def fastaContigLengths(fastafile: str) -> Dict[str, int]:
@@ -57,79 +55,41 @@ def fastaContigLengths(fastafile: str) -> Dict[str, int]:
 
 
 def fastaNonNContigLengths(fastafile: str) -> Dict[str, int]:
-    """Return contig lengths in a fasta file excluding
-    N bases.
+    """Return contig lengths in a FASTA file excluding N bases.
 
-    Args:
-        fastafile: Path to the FASTA file
+    The original implementation relied on ``grep``/``wc`` and ``samtools faidx``
+    subprocess calls.  ``pysam`` exposes the same functionality directly, so we
+    iterate over each contig and count the number of A/C/G/T characters.
 
-    Returns:
-        Dictionary mapping contig names to non-N lengths
+    Parameters
+    ----------
+    fastafile
+        Path to the FASTA file (must be indexed).
+
+    Returns
+    -------
+    Dict[str, int]
+        Mapping of contig names to non-N base counts. A special key ``"all"``
+        contains the total count across all contigs.
     """
-    # FIXME -- this could be made more efficient by using Python code
-    #          instead of calling out
-    #
-    # NOTE: This code uses a subprocess call to 'grep' which counts the number of
-    # non-N characters in the FASTA file for each contig.
-    fd, temp_path = tempfile.mkstemp(prefix="fasta_tmp")
-    os.close(fd)
+
+    if not os.path.exists(fastafile + ".fai"):
+        raise Exception(f"Fasta file {fastafile} is not indexed")
+
+    result: Dict[str, int] = {}
+    total = 0
+
+    fasta = pysam.FastaFile(fastafile)
     try:
-        cmd_line = "cat {} | grep -v '>' | tr -cd 'ACGTacgt' | wc -c > {}".format(
-            shlex.quote(fastafile),
-            shlex.quote(temp_path),
-        )
-        logging.info(cmd_line)
-
-        po = subprocess.Popen(
-            cmd_line,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
-        )
-
-        stdout, stderr = po.communicate()
-
-        po.wait()
-
-        return_code = po.returncode
-
-        if return_code != 0:
-            logging.error("cat | grep | tr | wc error: %s" % stderr)
-            raise Exception("Failed to count non-N bases in %s" % fastafile)
-
-        value = int(open(temp_path, encoding="utf-8").read().strip())
-        result = {"all": value}
-
-        # also figure contig-by-contig
-        contigs = fastaContigLengths(fastafile)
-        for contig in contigs:
-            cmd_line = f"samtools faidx {shlex.quote(fastafile)} {shlex.quote(contig)} | grep -v '>' | tr -cd 'ACGTacgt' | wc -c"
-            logging.debug(cmd_line)
-
-            po = subprocess.Popen(
-                cmd_line,
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                universal_newlines=True,
-            )
-
-            stdout, stderr = po.communicate()
-
-            po.wait()
-
-            return_code = po.returncode
-
-            if return_code != 0:
-                logging.error("samtools faidx | grep | tr | wc error: %s" % stderr)
-                raise Exception(f"Failed to count non-N bases in {fastafile}:{contig}")
-
-            result[contig] = int(stdout.strip())
+        for contig in fasta.references:
+            seq = fasta.fetch(contig).upper()
+            count = sum(base in "ACGT" for base in seq)
+            result[contig] = count
+            total += count
     finally:
-        with contextlib.suppress(Exception):
-            os.unlink(temp_path)
+        fasta.close()
 
+    result["all"] = total
     return result
 
 

--- a/src/hap_py/tools/vcfcallerinfo.py
+++ b/src/hap_py/tools/vcfcallerinfo.py
@@ -10,10 +10,11 @@
 
 import contextlib
 import json
-import logging
 import os
 import subprocess
 import tempfile
+
+import pysam
 
 
 class CallerInfo:
@@ -141,40 +142,24 @@ class CallerInfo:
         """Extract aligner information from a BAM file
         :param bamfile: name of BAM file
         """
-        sp = subprocess.Popen(
-            "samtools view -H '%s'" % bamfile,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        o, e = sp.communicate()
+        # ``pysam`` can read BAM headers directly; avoid external ``samtools``.
+        try:
+            bam = pysam.AlignmentFile(bamfile, "rb")
+        except Exception as ex:
+            raise Exception(f"Failed to open {bamfile}: {ex}") from ex
 
-        if sp.returncode != 0:
-            raise Exception(f"Samtools call failed: {o} / {e}")
-
-        for line in o.split("\n"):
-            if not line.startswith("@PG"):
-                continue
-            try:
-                # noinspection PyTypeChecker
-                x = dict(y.split(":", 1) for y in line.split("\t")[1:])
-            except Exception:
-                logging.warn("Unable to parse SAM/BAM header line: %s" % line)
-                continue
+        for pg in bam.header.to_dict().get("PG", []):
             cp = ["unknown", "unknown", ""]
-            try:
-                cp[0] = x["PN"]
-            except Exception:
-                try:
-                    cp[0] = x["ID"]
-                    if "-" in cp[0]:
-                        cp[0] = cp[0].split("-")[0]
-                except Exception:
-                    pass
-            with contextlib.suppress(Exception):
-                cp[1] = x["VN"]
+            name = pg.get("PN") or pg.get("ID")
+            if name:
+                cp[0] = name.split("-")[0]
 
             with contextlib.suppress(Exception):
-                cp[2] = x["CL"]
+                cp[1] = pg.get("VN", "unknown")
+
+            with contextlib.suppress(Exception):
+                cp[2] = pg.get("CL", "")
 
             self.aligners.append(cp)
+
+        bam.close()

--- a/src/hap_py/tools/vcfextract.py
+++ b/src/hap_py/tools/vcfextract.py
@@ -13,8 +13,9 @@ import gzip
 import json
 import logging
 import re
-import subprocess
 from typing import Any, Dict, List, Optional, Union
+
+import pysam
 
 
 def field(val: str) -> Union[int, float, str, List[Any]]:
@@ -207,17 +208,11 @@ def extract_header(
         if file_handle:
             file_handle.close()
 
-    # Add tabix information if available
+    # Add tabix information if available using pysam
     try:
-        import subprocess
-
-        tabix_output = subprocess.check_output(
-            ["tabix", "-l", filename], text=True, stderr=subprocess.PIPE
-        )
-        chromosomes = [
-            line.strip() for line in tabix_output.split("\n") if line.strip()
-        ]
-        result["tabix"] = {"chromosomes": chromosomes}
+        tbx = pysam.TabixFile(filename)
+        result["tabix"] = {"chromosomes": list(tbx.contigs)}
+        tbx.close()
     except Exception:
         result["tabix"] = None
 
@@ -238,30 +233,24 @@ def extract_variants(
         region: Region to extract from, e.g. chr1:1000-2000
         extract_samples: When true, extract sample information
         sample_names: List of sample names to extract (None = all samples)
-        tabix_path: Path to tabix executable
+        tabix_path: Deprecated and ignored. ``pysam`` is used instead.
 
     Returns:
         List of variant records as dictionaries
     """
-    if not tabix_path:
-        # Try to find tabix in PATH
-        tabix_path = "tabix"  # Assume it's in PATH
-
-    command = [tabix_path, filename]
+    # Use pysam to read the bgzipped + indexed VCF instead of spawning tabix
+    tbx = pysam.TabixFile(filename)
 
     if region:
-        command.append(region)
+        iterator = tbx.fetch(region=region)
+    else:
+        iterator = tbx.fetch()
 
     result = []
 
-    p = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
-    )
-
     header = extract_header(filename, extract_columns=True)
     columns = header.get("columns", [])
-
-    for line in p.stdout:
+    for line in iterator:
         line = line.strip()
         if not line or line.startswith("#"):
             continue
@@ -306,14 +295,7 @@ def extract_variants(
 
         result.append(record)
 
-    # Check for errors
-    stderr_output = p.stderr.read()
-    if stderr_output:
-        logging.warning(f"Tabix stderr: {stderr_output}")
-
-    exit_code = p.wait()
-    if exit_code != 0:
-        logging.error(f"Tabix exited with code {exit_code}")
+    tbx.close()
 
     return result
 


### PR DESCRIPTION
## Summary
- remove bgzip subprocess calls and use `pysam.BGZFile`
- fetch VCF lines with `pysam.TabixFile` instead of `tabix`
- count FASTA bases and read BAM headers with pysam
- merge VCF files using pysam instead of `bcftools`

Remaining shell commands (for future investigation):
- complex `bcftools` pipelines in `tools/bcftools.py`
- external `vcfhdr2json` helper in `vcfcallerinfo.py`

## Testing
- `pre-commit run --files src/hap_py/tools/__init__.py src/hap_py/tools/vcfextract.py src/hap_py/tools/fastasize.py src/hap_py/tools/vcfcallerinfo.py src/hap_py/haplo/quantify.py`
- `pytest -k fastasize -q`

------
https://chatgpt.com/codex/tasks/task_e_6849eec5ebd8832ca0738d6ff501aac3