### PR TITLE
Update tests for CLI path assumptions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,19 @@ def get_rtg_path():
         print(f"Found RTG tools at {rtg_path}")
         return str(rtg_path)
 
+    # Look in the user's home directory and common subdirectories
+    home = Path.home()
+    home_candidates = [
+        home / "rtg",
+        home / "rtg" / "rtg",
+        home / "bin" / "rtg",
+        home / ".local" / "bin" / "rtg",
+        home / ".local" / "rtg" / "rtg",
+    ]
+    for candidate in home_candidates:
+        if candidate.exists():
+            return str(candidate)
+
     # Try project root (where the rtg symlink might be)
     rtg_path = project_root / "rtg"
     if rtg_path.exists():

--- a/tests/integration/test_chrprefix.py
+++ b/tests/integration/test_chrprefix.py
@@ -12,8 +12,6 @@ import pytest
 
 from tests.utils import (
     compare_files_content,
-    get_bin_dir,
-    get_python_executable,
     get_src_data_dir,
     validate_output_files,
 )
@@ -49,11 +47,8 @@ def test_numeric_chrs(tmp_path, rtg_executable):
     output_summary = Path(str(output_prefix) + ".summary.csv")
 
     # Run hap.py on numeric chromosome files using CLI command
-    python_exe = get_python_executable()
-    hap_py_script = get_bin_dir() / "hap.py"
     cmd = [
-        python_exe,
-        str(hap_py_script),
+        "hap.py",
         str(truth_vcf),
         str(query_vcf),
         "-f",
@@ -131,11 +126,8 @@ def test_chr_prefixed(tmp_path, rtg_executable):
     output_summary = Path(str(output_prefix) + ".summary.csv")
 
     # Run hap.py on chr-prefixed files using CLI command
-    python_exe = get_python_executable()
-    hap_py_script = get_bin_dir() / "hap.py"
     cmd = [
-        python_exe,
-        str(hap_py_script),
+        "hap.py",
         str(truth_vcf),
         str(query_vcf),
         "-f",
@@ -206,11 +198,8 @@ def test_mixed_chr_prefix(tmp_path, rtg_executable):
     output_summary = Path(str(output_prefix) + ".summary.csv")
 
     # Run hap.py with mixed chromosome naming using CLI command
-    python_exe = get_python_executable()
-    hap_py_script = get_bin_dir() / "hap.py"
     cmd = [
-        python_exe,
-        str(hap_py_script),
+        "hap.py",
         str(truth_vcf),
         str(query_vcf),
         "-f",

--- a/tests/integration/test_decomp.py
+++ b/tests/integration/test_decomp.py
@@ -11,7 +11,6 @@ import pytest
 
 from tests.utils import (
     compare_summary_files,
-    get_bin_dir,
     get_example_dir,
     run_command,
 )
@@ -44,7 +43,7 @@ def test_decomp(tmp_path, rtg_executable, reference_file):
 
     # Run hap.py with the same parameters as in the shell script
     cmd = [
-        str(get_bin_dir() / "hap.py"),
+        "hap.py",
         str(truth_vcf),
         str(query_vcf),
         "-f",

--- a/tests/integration/test_faulty_variants.py
+++ b/tests/integration/test_faulty_variants.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.utils import get_bin_dir, get_src_data_dir
+from tests.utils import get_src_data_dir
 
 
 @pytest.mark.integration
@@ -42,7 +42,7 @@ def test_faulty_variant_handling(temp_dir, rtg_executable):
 
     # Test 1: hap.py with valid inputs
     cmd = [
-        str(get_bin_dir() / "hap.py"),
+        "hap.py",
         str(test_vcf),
         str(test_q_vcf),
         "-o",
@@ -74,7 +74,7 @@ def test_faulty_variant_handling(temp_dir, rtg_executable):
 
     # Test 2: hap.py with faulty inputs - should fail
     cmd = [
-        str(get_bin_dir() / "hap.py"),
+        "hap.py",
         str(test_vcf),
         str(test_q_failure_vcf),
         "-o",
@@ -111,7 +111,7 @@ def test_faulty_variant_pre_py(temp_dir):
 
     # Run pre.py with faulty input - should fail
     cmd = [
-        str(get_bin_dir() / "preprocess"),
+        "preprocess",
         str(faulty_vcf),
         str(output_file),
         "--reference",

--- a/tests/integration/test_fp_accuracy.py
+++ b/tests/integration/test_fp_accuracy.py
@@ -11,8 +11,6 @@ import pytest
 from tests.utils import (
     compare_files,
     compare_summary_files,
-    get_bin_dir,
-    get_python_executable,
     get_src_data_dir,
     require_tools,
     run_shell_command,
@@ -36,9 +34,6 @@ def extract_and_filter_vcf(gz_file: Path, output_file: Path) -> None:
 def test_fp_region_accuracy(tmp_path, rtg_executable):
     """Test if FP regions are processed accurately."""
     # Get paths to required files and tools
-    bin_dir = get_bin_dir()
-    python_exe = get_python_executable()
-
     # Skip if required external tools are missing
     require_tools("rtg", "bcftools", "bgzip", "tabix")
 
@@ -56,8 +51,7 @@ def test_fp_region_accuracy(tmp_path, rtg_executable):
 
     # Run hap.py with FP region
     happy_cmd = [
-        python_exe,
-        str(bin_dir / "hap.py"),
+        "hap.py",
         str(truth_vcf),
         str(query_vcf),
         "-f",

--- a/tests/integration/test_giab.py
+++ b/tests/integration/test_giab.py
@@ -9,7 +9,6 @@ import pytest
 
 from tests.utils import (
     compare_summary_files,
-    get_bin_dir,
     get_example_dir,
     run_command,
     validate_output_files,
@@ -42,7 +41,7 @@ def test_small_giab_rtg(tmp_path, rtg_executable, reference_file):
 
     # Run hap.py with the same parameters as in the shell script
     cmd = [
-        str(get_bin_dir() / "hap.py"),
+        "hap.py",
         str(nist_vcf),
         str(rtg_vcf),
         "-r",
@@ -97,7 +96,7 @@ def test_large_giab_rtg_chr21(tmp_path, rtg_executable, reference_file):
 
     # Run hap.py with the same parameters as in the shell script
     cmd = [
-        str(get_bin_dir() / "hap.py"),
+        "hap.py",
         str(nist_vcf),
         str(rtg_vcf),
         "-r",
@@ -161,7 +160,7 @@ def test_large_giab_rtg_chr1(tmp_path, rtg_executable, reference_file):
 
     # Run hap.py with the same parameters as in the shell script
     cmd = [
-        str(get_bin_dir() / "hap.py"),
+        "hap.py",
         str(nist_vcf),
         str(rtg_vcf),
         "-r",

--- a/tests/integration/test_gvcf_homref.py
+++ b/tests/integration/test_gvcf_homref.py
@@ -7,8 +7,8 @@ import pytest
 
 from tests.utils import (
     compress_and_index_vcf,
-    get_bin_dir,
     get_example_dir,
+    get_python_executable,
     run_shell_command,
 )
 
@@ -17,7 +17,6 @@ from tests.utils import (
 def test_gvcf_homref(tmp_path):
     """Test multimerge functionality with homref blocks."""
     # Get paths to required files and tools
-    bin_dir = get_bin_dir()
     example_dir = get_example_dir()
 
     # Set up paths
@@ -35,7 +34,9 @@ def test_gvcf_homref(tmp_path):
 
     # Run multimerge with homref options
     multimerge_cmd = [
-        str(bin_dir / "multimerge"),
+        get_python_executable(),
+        "-m",
+        "hap_py.utils.multimerge",
         str(homref_vcf_gz),
         str(homref2_vcf_gz),
         "-o",
@@ -59,7 +60,6 @@ def test_gvcf_homref(tmp_path):
 def test_gvcf_homref_with_variants(tmp_path):
     """Test multimerge functionality with homref blocks and variants."""
     # Get paths to required files and tools
-    bin_dir = get_bin_dir()
     example_dir = get_example_dir()
 
     # Set up paths
@@ -75,7 +75,9 @@ def test_gvcf_homref_with_variants(tmp_path):
 
     # Run multimerge with homref and variants options
     multimerge_cmd = [
-        str(bin_dir / "multimerge"),
+        get_python_executable(),
+        "-m",
+        "hap_py.utils.multimerge",
         f"{call_merge_vcf_gz}:*",
         "-o",
         str(output_vcf),

--- a/tests/integration/test_happy_pg.py
+++ b/tests/integration/test_happy_pg.py
@@ -8,9 +8,7 @@ import pytest
 from tests.utils import (
     check_vcfeval_availability,
     compare_summary_files,
-    get_bin_dir,
     get_example_dir,
-    get_python_executable,
     require_tools,
     run_shell_command,
 )
@@ -21,9 +19,7 @@ from tests.utils import (
 def test_happy_pg_test(tmp_path):
     """Test PG evaluation for hap.py with different engine options."""
     # Get paths to required files and tools
-    bin_dir = get_bin_dir()
     example_dir = get_example_dir()
-    python_exe = get_python_executable()
 
     # Skip if required external tools are missing
     require_tools("bcftools", "bgzip", "tabix")
@@ -50,8 +46,7 @@ def test_happy_pg_test(tmp_path):
     # If vcfeval is available, run hap.py with vcfeval engine
     if has_vcfeval:
         vcfeval_cmd = [
-            python_exe,
-            str(bin_dir / "hap.py"),
+            "hap.py",
             "-l",
             "chr21",
             str(truth_vcf),
@@ -79,8 +74,7 @@ def test_happy_pg_test(tmp_path):
 
     # Run standard hap.py
     standard_cmd = [
-        python_exe,
-        str(bin_dir / "hap.py"),
+        "hap.py",
         "-l",
         "chr21",
         str(truth_vcf),
@@ -107,8 +101,7 @@ def test_happy_pg_test(tmp_path):
 
     # Run hap.py with pass-only option
     pass_cmd = [
-        python_exe,
-        str(bin_dir / "hap.py"),
+        "hap.py",
         "-l",
         "chr21",
         str(truth_vcf),
@@ -136,8 +129,7 @@ def test_happy_pg_test(tmp_path):
 
     # Run hap.py with unhappy and ROC option
     unhappy_cmd = [
-        python_exe,
-        str(bin_dir / "hap.py"),
+        "hap.py",
         "-l",
         "chr21",
         str(truth_vcf),

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -12,7 +12,6 @@ from tests.utils import (
     compare_summary_files,
     compress_and_index_vcf,
     find_reference_file,
-    get_bin_dir,
     get_example_dir,
     get_python_executable,
     run_shell_command,
@@ -53,9 +52,7 @@ def compare_vcf_files(file1: Path, file2: Path) -> bool:
 def test_integration(tmp_path):
     """Test hap.py integration with different input configurations."""
     # Get paths to required files and tools
-    bin_dir = get_bin_dir()
     example_dir = get_example_dir()
-    python_exe = get_python_executable()
 
     # Set up paths to example files
     integration_dir = example_dir / "integration"
@@ -86,7 +83,9 @@ def test_integration(tmp_path):
     # Test multimerge functionality
     multimerge_output = tmp_path / "multimerge_output.vcf"
     multimerge_cmd = [
-        str(bin_dir / "multimerge"),
+        get_python_executable(),
+        "-m",
+        "hap_py.utils.multimerge",
         str(lhs_vcf_gz),
         str(rhs_vcf_gz),
         "-o",
@@ -108,8 +107,7 @@ def test_integration(tmp_path):
     # Test hap.py with empty truth file
     empty_truth_output = output_prefix.with_suffix(".e0")
     empty_truth_cmd = [
-        python_exe,
-        str(bin_dir / "hap.py"),
+        "hap.py",
         "-l",
         "chr21",
         "-r",
@@ -131,8 +129,7 @@ def test_integration(tmp_path):
     # Test hap.py with empty query file
     empty_query_output = output_prefix.with_suffix(".e1")
     empty_query_cmd = [
-        python_exe,
-        str(bin_dir / "hap.py"),
+        "hap.py",
         "-l",
         "chr21",
         "-r",
@@ -153,8 +150,7 @@ def test_integration(tmp_path):
 
     # Test standard hap.py
     standard_cmd = [
-        python_exe,
-        str(bin_dir / "hap.py"),
+        "hap.py",
         "-l",
         "chr21",
         "-r",
@@ -182,8 +178,7 @@ def test_integration(tmp_path):
     # Test unhappy mode
     unhappy_output = output_prefix.with_suffix(".unhappy")
     unhappy_cmd = [
-        python_exe,
-        str(bin_dir / "hap.py"),
+        "hap.py",
         "-l",
         "chr21",
         "-r",
@@ -212,8 +207,7 @@ def test_integration(tmp_path):
     # Test pass-only mode
     pass_output = output_prefix.with_suffix(".pass")
     pass_cmd = [
-        python_exe,
-        str(bin_dir / "hap.py"),
+        "hap.py",
         "-l",
         "chr21",
         "-r",

--- a/tests/integration/test_integration_quantify.py
+++ b/tests/integration/test_integration_quantify.py
@@ -10,10 +10,8 @@ import pytest
 
 from tests.utils import (
     compare_summary_files,
-    get_bin_dir,
     get_example_dir,
     get_project_root,
-    get_python_executable,
     run_shell_command,
 )
 
@@ -24,9 +22,7 @@ def test_quantify_test(tmp_path):
     """Test quantification and GA4GH intermediate file format compliance."""
     # Get paths to required files and tools
     get_project_root()
-    bin_dir = get_bin_dir()
     example_dir = get_example_dir()
-    python_exe = get_python_executable()
 
     # Prepare file paths
     reference_fa = example_dir / "chr21.fa"
@@ -41,8 +37,7 @@ def test_quantify_test(tmp_path):
 
     # Run hap.py
     hap_py_cmd = [
-        python_exe,
-        str(bin_dir / "hap.py"),
+        "hap.py",
         "-l",
         "chr21",
         str(truth_vcf),
@@ -74,8 +69,7 @@ def test_quantify_test(tmp_path):
     # Run qfy.py for re-quantification using GA4GH spec
     qfy_output_prefix = output_prefix.with_suffix(".qfy")
     qfy_cmd = [
-        python_exe,
-        str(bin_dir / "qfy.py"),
+        "quantify",
         str(output_prefix.with_suffix(".vcf.gz")),
         "-o",
         str(qfy_output_prefix),

--- a/tests/integration/test_multimerge.py
+++ b/tests/integration/test_multimerge.py
@@ -9,7 +9,7 @@ import subprocess
 import pytest
 
 from tests.utils import (
-    get_bin_dir,
+    get_python_executable,
     get_src_data_dir,
     require_tools,
     run_command,
@@ -21,7 +21,6 @@ from tests.utils import (
 def test_multimerge_basic(tmp_path):
     """Test basic multimerge functionality (test 1)."""
     # Get paths to required files and tools
-    bin_dir = get_bin_dir()
     src_data_dir = get_src_data_dir()
 
     # Define input and output files
@@ -31,16 +30,13 @@ def test_multimerge_basic(tmp_path):
     expected_merge_vcf = src_data_dir / "expected_merge.vcf"
     temp_vcf = tmp_path / "temp.vcf"
 
-    # Define path to multimerge binary
-    multimerge_bin = bin_dir / "multimerge"
-
-    # Skip test if binary doesn't exist
-    if not multimerge_bin.exists():
-        pytest.skip(f"multimerge binary not found at {multimerge_bin}")
+    # Use Python module implementation
 
     # Run the multimerge command
     cmd = [
-        str(multimerge_bin),
+        get_python_executable(),
+        "-m",
+        "hap_py.utils.multimerge",
         f"{merge1_vcf}:NA12877",
         f"{merge2_vcf}:NA12878",
         "-o",
@@ -68,7 +64,6 @@ def test_multimerge_basic(tmp_path):
 def test_multimerge_import(tmp_path):
     """Test multimerge data import functionality."""
     # Get paths to required files and tools
-    bin_dir = get_bin_dir()
     src_data_dir = get_src_data_dir()
 
     # Define input and output files
@@ -77,15 +72,8 @@ def test_multimerge_import(tmp_path):
     expected_import_vcf = src_data_dir / "expected_importtest.vcf"
     temp_vcf = tmp_path / "temp_import.vcf"
 
-    # Define path to multimerge binary
-    multimerge_bin = bin_dir / "multimerge"
-
     # Skip if required external tools are missing
     require_tools("bgzip", "tabix")
-
-    # Skip test if binary doesn't exist
-    if not multimerge_bin.exists():
-        pytest.skip(f"multimerge binary not found at {multimerge_bin}")
 
     # Ensure the input file is prepared with bgzip and tabix
     # In a real test, we'd check if these steps are needed, but for demonstration:
@@ -99,7 +87,9 @@ def test_multimerge_import(tmp_path):
 
     # Run the multimerge command
     cmd = [
-        str(multimerge_bin),
+        get_python_executable(),
+        "-m",
+        "hap_py.utils.multimerge",
         f"{import_errors_vcf}:NA12877",
         "-o",
         str(temp_vcf),


### PR DESCRIPTION
## Summary
- improve RTG path lookup to check `.local` & home directories
- call installed `hap.py`/`preprocess`/`quantify` directly in integration tests
- update multimerge tests to invoke Python implementation

## Testing
- `pytest tests/integration -v` *(fails: 7 failed, 3 passed, 17 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6849fa598f40832c846a71a39ccc9d16