### PR TITLE
Add more unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Python CI
 
 on:
   push:
-    branches: [ main, dev-code, dev-copilot  ]
+    branches: [ main, dev-code, dev-codex, dev-copilot ]
   pull_request:
     branches: [ main, dev-codex, dev-copilot ]
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -2,9 +2,9 @@ name: Python CI
 
 on:
   push:
-    branches: [ main ] # Or your default branch
+    branches: [ main, dev-codex ]
   pull_request:
-    branches: [ main ] # Or your default branch
+    branches: [ main, dev-codex ]
 
 jobs:
   build_and_test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,14 +9,14 @@ globs: *
 hap.py is a bioinformatics tool for benchmarking small variant calls, widely used for evaluating the accuracy of variant callers in the genomics community. The original codebase used Python 2 (now end-of-life) and had outdated dependencies. This fork aims to modernize the codebase for continued use and development.
 
 ## Repository Structure
-- `src/`: Main source code directory  
-  - `hap_py/`: Core Python package (modernized from the original `src/python` code)  
-  - `c++/`: (Legacy) C++ algorithms (most have been reimplemented in Python for maintainability)  
-  - `sh/`: Shell scripts for testing and utility functions  
-  - `data/`: Reference data files for examples and tests  
-- `external/`: External dependencies (e.g. bundled tools like htslib, rtg-tools)  
-- `example/`: Example usage data and test data sets  
-- `tests/`: Unit and integration tests  
+- `src/`: Main source code directory
+  - `hap_py/`: Core Python package (modernized from the original `src/python` code)
+  - `c++/`: (Legacy) C++ algorithms (most have been reimplemented in Python for maintainability)
+  - `sh/`: Shell scripts for testing and utility functions
+  - `data/`: Reference data files for examples and tests
+- `external/`: External dependencies (e.g. bundled tools like htslib, rtg-tools)
+- `example/`: Example usage data and test data sets
+- `tests/`: Unit and integration tests
 - `scripts/`: Development and build scripts
 
 ## Project Status and Roadmap
@@ -28,27 +28,27 @@ hap.py is a bioinformatics tool for benchmarking small variant calls, widely use
 
 ### In Progress
 - [ ] **C++ modernization & performance** – Optimize any remaining C/C++ components and consider reintroducing C++ only where performance dictates. Improve memory usage and parallelization in analysis algorithms to handle large genomic datasets efficiently.
-- [ ] **`quantify` module implementation** – Finalize the modernization of the `quantify` benchmarking module in phases:  
-    - [x] *Phase 1:* Core variant matching functionality (`_match_variants`) – **Completed.**  
-    - [ ] *Phase 2:* Enhanced ROC analysis (methods like `_perform_roc_analysis()`, `_perform_quality_stratification()`, `_generate_roc_curve()`, etc.) – **In Progress.**  
-    - [ ] *Phase 3:* Superlocus analysis – **Planned.**  
-    - [ ] *Phase 4:* Scaling and performance optimization for large datasets – **Planned.**  
-    - [ ] *Phase 5:* GA4GH compliance and standards support – **Planned.**  
+- [ ] **`quantify` module implementation** – Finalize the modernization of the `quantify` benchmarking module in phases:
+    - [x] *Phase 1:* Core variant matching functionality (`_match_variants`) – **Completed.**
+    - [ ] *Phase 2:* Enhanced ROC analysis (methods like `_perform_roc_analysis()`, `_perform_quality_stratification()`, `_generate_roc_curve()`, etc.) – **In Progress.**
+    - [ ] *Phase 3:* Superlocus analysis – **Planned.**
+    - [ ] *Phase 4:* Scaling and performance optimization for large datasets – **Planned.**
+    - [ ] *Phase 5:* GA4GH compliance and standards support – **Planned.**
     *(Phase 1 is complete with tests passing; Phases 2–5 are upcoming development focus.)*
 - [ ] **Integration test stabilization** – Continue resolving failing integration tests related to reference data handling, output file expectations (e.g. presence of `roc.tsv`), and external tool invocation to ensure the test suite passes reliably.
 
 ### Future Plans
-- [ ] **CI/CD pipeline** – Set up continuous integration (automated testing, linting) and continuous deployment for the project.  
-- [ ] **Containerization** – Provide Docker or Conda environments for easier deployment and reproducibility of hap.py in different systems.  
+- [ ] **CI/CD pipeline** – Set up continuous integration (automated testing, linting) and continuous deployment for the project.
+- [ ] **Containerization** – Provide Docker or Conda environments for easier deployment and reproducibility of hap.py in different systems.
 - [ ] **Documentation** – Expand user documentation and tutorials (e.g. README updates, example usage guides) once the codebase changes stabilize.
 
 ## Development Environment Setup
 ### Prerequisites
-- Python 3.8+ (recommend Python 3.11 for best compatibility)  
-- CMake 3.10+  
-- C++ compiler (GCC 7+ or Clang 10+)  
-- Git  
-- **Environment management:** micromamba (recommended) or conda/mamba  
+- Python 3.8+ (recommend Python 3.11 for best compatibility)
+- CMake 3.10+
+- C++ compiler (GCC 7+ or Clang 10+)
+- Git
+- **Environment management:** micromamba (recommended) or conda/mamba
 - **Bioinformatics tools:** Ensure `bcftools` and `samtools` are installed for certain tests. `bgzip`/`tabix` are optional as the code now defaults to the `pysam` Python implementation.
 
 ### Initial Setup
@@ -56,33 +56,33 @@ hap.py is a bioinformatics tool for benchmarking small variant calls, widely use
    ```bash
    git clone <repository-url>
    cd hap.py
-   ```  
+   ```
 2. **Create and activate the development environment:**
    - Using **micromamba** (recommended):
      ```bash
      micromamba create -n happy-dev python=3.11
      micromamba activate happy-dev
-     ```  
+     ```
    - Using **venv** (alternative):
      ```bash
      python3 -m venv .venv
      source .venv/bin/activate  # (Windows: .venv\Scripts\activate)
-     ```  
+     ```
    **Important:** For all development work, use the `happy-dev` environment:
    ```bash
    micromamba activate happy-dev
-   ```  
+   ```
 3. **Install project in development mode with dependencies:**
    ```bash
    pip install -e ".[dev,cpp]"
    # Install pre-commit hooks for code quality
    pre-commit install
-   ```  
+   ```
 4. **Build external dependencies (if any):**
    ```bash
    cmake -B build -S .
    cmake --build build
-   ```  
+   ```
 5. **Configure environment variables (if needed):**
    ```bash
    # Example: reference genome path for tests
@@ -91,10 +91,10 @@ hap.py is a bioinformatics tool for benchmarking small variant calls, widely use
 
 ### Code Quality Tools
 The project uses several tools to maintain code quality and style:
-- **Black** – code formatter (with 88-character line limit)  
-- **Ruff** – linter for Python (fast, includes flake8/pyflakes checks)  
-- **isort** – import statement sorter (configurations compatible with Black)  
-- **mypy** – static type checker for Python  
+- **Black** – code formatter (with 88-character line limit)
+- **Ruff** – linter for Python (fast, includes flake8/pyflakes checks)
+- **isort** – import statement sorter (configurations compatible with Black)
+- **mypy** – static type checker for Python
 - **pre-commit** – framework for running linters/formatters on each commit
 
 ### Running Code Quality Checks
@@ -118,65 +118,65 @@ pre-commit run --all-files
 
 ## Testing
 ### Test Structure
-- **Unit tests:** `tests/unit/` cover individual modules and functions (fast, isolated tests).  
-- **Integration tests:** `tests/integration/` cover end-to-end scenarios and require external tools or data.  
+- **Unit tests:** `tests/unit/` cover individual modules and functions (fast, isolated tests).
+- **Integration tests:** `tests/integration/` cover end-to-end scenarios and require external tools or data.
 - **Shared test utilities:** `tests/utils.py` provides common helper functions for tests, with configuration in `conftest.py`.
 
 ### Running Tests
 > **Note:** Always activate the `happy-dev` environment before running tests:
 > ```bash
 > micromamba activate happy-dev
-> ``` 
+> ```
 
 - **Run all unit tests:**
   ```bash
   pytest tests/unit/ -v
-  ```  
+  ```
 - **Run a specific unit test file:**
   ```bash
   pytest tests/unit/test_vcfeval.py -v
-  ```  
+  ```
 - **Run with coverage:**
   ```bash
   pytest tests/unit/ --cov=hap_py --cov-report=html
-  ```  
+  ```
 - **Run all integration tests** (requires external tools like RTG and access to example data):
   ```bash
   pytest tests/integration/ -v
-  ```  
+  ```
 - **Run a specific integration test:**
   ```bash
   pytest tests/integration/test_performance.py -v
-  ```  
+  ```
 - **Skip slow tests** (skip tests marked as slow):
   ```bash
   pytest tests/integration/ -v -m "not slow"
-  ```  
+  ```
 - **Run full test suite (all tests):**
   ```bash
   pytest tests/ -v
-  ```  
+  ```
   (Use `-n auto` with `pytest-xdist` to run tests in parallel, if installed.)
 
 ### Test Markers
-- `@pytest.mark.integration` – marks tests that require external tools or large data.  
-- `@pytest.mark.slow` – marks long-running tests.  
+- `@pytest.mark.integration` – marks tests that require external tools or large data.
+- `@pytest.mark.slow` – marks long-running tests.
 - `@pytest.mark.cpp` – marks tests that depend on C++ components (if any remain; many C++ parts have been replaced with Python).
 
 ### Common Test Issues (from Modernization)
 During the transition from Python 2 to Python 3 and restructuring of the project, a few common issues were addressed:
-1. **Import paths** – The package name changed. For example:  
+1. **Import paths** – The package name changed. For example:
    ```python
    # Old import style (pre-modernization)
    import haplo.vcfeval
 
    # New import style (post-modernization)
    import hap_py.haplo.vcfeval
-   ```  
+   ```
    Ensure tests use the updated `hap_py` package imports. Also verify that each package directory contains an `__init__.py` (so Python recognizes the package).
 2. **Module not found errors** – Double-check that the `src/hap_py/` directory is on the Python path during testing. Installing in dev mode (`pip install -e .`) or using `pytest` from the repo root helps set this up. Missing `__init__.py` files in `tests/` subdirectories can also cause import errors (make sure `tests/` and its subfolders have `__init__.py`).
 3. **String vs. bytes** – Use utility functions to handle byte strings vs Unicode strings. For instance, the project provides `ensure_str()` and `ensure_bytes()` in `hap_py.haplo.string_handling`. Use these when reading outputs from subprocesses to avoid type mismatches between Python 3 (which uses Unicode `str`) and older code expecting bytes.
-4. **File path differences** – Use `pathlib.Path` for file paths to ensure cross-platform compatibility:  
+4. **File path differences** – Use `pathlib.Path` for file paths to ensure cross-platform compatibility:
    ```python
    from pathlib import Path
 
@@ -185,26 +185,26 @@ During the transition from Python 2 to Python 3 and restructuring of the project
 
    # New way:
    test_file = Path(__file__).parent / "data" / "test.vcf"
-   ```  
+   ```
    This makes path manipulations clearer and OS-agnostic.
-5. **External tool availability** – Tests relying on external tools (e.g., `bcftools`, `rtg`) should check for tool presence and skip if not available:  
+5. **External tool availability** – Tests relying on external tools (e.g., `bcftools`, `rtg`) should check for tool presence and skip if not available:
    ```python
    import shutil, pytest
    if not shutil.which("bcftools"):
        pytest.skip("bcftools not available")
-   ```  
+   ```
    Also ensure the RTG tools are built (expected at `build/external/rtg-tools/rtg`). If not present, tests should be skipped or the build instructions should be followed.
 
 ### Debugging Test Failures
 When a test fails, consider the following steps to diagnose the issue:
-1. **Check Python path and installation** – Confirm you are running tests in the correct environment and that `hap_py` is installed. For example:  
+1. **Check Python path and installation** – Confirm you are running tests in the correct environment and that `hap_py` is installed. For example:
    ```python
    import sys, hap_py
    print("Python path:", sys.path)
    print("hap_py location:", hap_py.__file__)
-   ```  
+   ```
    Running `pip list | grep hap-py` can also verify that the package is installed in the environment.
-2. **Verify external dependencies** – Ensure that required external tools and data are available:  
+2. **Verify external dependencies** – Ensure that required external tools and data are available:
    ```bash
    # List expected build outputs
    ls build/external/
@@ -213,10 +213,10 @@ When a test fails, consider the following steps to diagnose the issue:
    bcftools --version
    samtools --version
    ```
-3. **Run tests with verbose output** – Use `-s` (do not capture output) and `--tb=long` (full traceback) to get more insight into test failures:  
+3. **Run tests with verbose output** – Use `-s` (do not capture output) and `--tb=long` (full traceback) to get more insight into test failures:
    ```bash
    pytest tests/integration/test_some_failure.py -v -s --tb=long
-   ```  
+   ```
    This can reveal detailed error messages from subprocesses or assertion failures.
 
 ## Build and Installation
@@ -353,4 +353,23 @@ The following notable changes and fixes have been applied during the latest deve
 - **Header comparisons** – Integration tests ignore VCF header lines when comparing outputs, matching the behavior of the original shell scripts.
 - **Default compression with pysam** – Compression and indexing of VCF files use `pysam` by default; `bgzip` and `tabix` are optional fallbacks.
 
+## Unit Test Coverage Plan
 
+The goal is to rely on unit tests for most functionality. Add focused tests for
+new Python modules and edge cases. Integration tests should eventually be used
+only for a lightweight verification of the `hap.py` command line interface.
+
+To increase unit test coverage:
+
+1. Port complex logic from integration tests into unit tests. Target modules
+   like `python_preprocess`, `vcfeval`, and CLI wrappers.
+2. Use fixtures in `tests/conftest.py` to supply small reference files and VCF
+   examples rather than large example data.
+3. Mock external dependencies (pysam, subprocess) to isolate code paths.
+4. Keep a minimal set of integration tests for the overall command line tools
+   as sanity checks.
+5. Add unit tests for helper modules in `hap_py.tools` such as `bcftools`
+   and `bedintervaltree` to exercise parsing and interval logic.
+6. Incrementally convert integration test logic to smaller unit tests that
+   focus on specific functions. Use the integration suite only to verify
+   the `hap.py` CLI behaves correctly end-to-end.

--- a/src/hap_py/haplo/gvcf2bed.py
+++ b/src/hap_py/haplo/gvcf2bed.py
@@ -39,6 +39,11 @@ def gvcf2bed(
     Returns:
         Path to temporary BED file containing confident regions
     """
+    # TODO: ``ref`` argument is currently unused. Integrating reference-based
+    # validation would make this function more robust.
+    # TODO: The current implementation loads all variants into memory before
+    # merging. Streaming the input VCF would reduce peak memory usage for large
+    # files.
     logging.info(f"Converting VCF to BED regions: {vcf}")
 
     # Create temporary output file

--- a/src/hap_py/tools/bcftools.py
+++ b/src/hap_py/tools/bcftools.py
@@ -50,6 +50,9 @@ def runShellCommand(*args: str) -> CommandOutput:
     cmd_line = " ".join(qargs)
     logging.info(cmd_line)
 
+    # TODO: consider using ``subprocess.run`` with ``check=True`` for
+    # simpler error handling and to avoid potential security issues
+    # with ``shell=True``.
     po = subprocess.Popen(
         cmd_line,
         shell=True,

--- a/src/hap_py/tools/bedintervaltree.py
+++ b/src/hap_py/tools/bedintervaltree.py
@@ -19,6 +19,10 @@ from bx.intervals.intersection import Interval, IntervalTree
 class BedIntervalTree:
     """Reads in a BED file and converts it to an interval tree for searching"""
 
+    # TODO: ``bx-python`` interval trees are somewhat heavy-weight for simple
+    # region queries. Evaluate alternatives like ``pybedtools`` or ``numpy``
+    # based approaches to reduce memory overhead for very large BED files.
+
     def __init__(self):
         self.tree = defaultdict(IntervalTree)
         self.intCount = 0

--- a/src/hap_py/utils/multimerge.py
+++ b/src/hap_py/utils/multimerge.py
@@ -34,7 +34,10 @@ def _merge_records(
     opened_vcfs: list[tuple[pysam.VariantFile, str]] = []
     records: dict[tuple[str, int, str], pysam.VariantRecord] = {}
 
-    # Open all VCFs first to build the combined header
+    # Open all VCFs first to build the combined header.
+    # TODO: The current implementation only preserves genotype (GT) fields and
+    # ignores other annotations. A more complete merge should handle all INFO
+    # and FORMAT fields consistently.
     for vcf_path, sample in inputs:
         vcf = _read_vcf(vcf_path)
         opened_vcfs.append((vcf, sample))
@@ -50,6 +53,8 @@ def _merge_records(
             header.add_sample(sample)
 
     for vcf, sample in opened_vcfs:
+        # TODO: Streaming records would avoid constructing a potentially large
+        # in-memory dictionary when merging many files.
         for rec in vcf.fetch():
             key = (rec.chrom, rec.pos, rec.ref)
             if key not in records:

--- a/tests/unit/test_bcftools.py
+++ b/tests/unit/test_bcftools.py
@@ -1,0 +1,41 @@
+import gzip
+from pathlib import Path
+
+import pytest
+
+from hap_py.tools.bcftools import countVCFRows, parseStats, runShellCommand
+
+
+def test_run_shell_command_success():
+    stdout, stderr, rc = runShellCommand("echo", "hello")
+    assert stdout.strip() == "hello"
+    assert rc == 0
+
+
+def test_run_shell_command_failure():
+    with pytest.raises(Exception):
+        runShellCommand("nonexistent_command_xyz")
+
+
+def test_parse_stats():
+    output = "SN\t0\tnumber of records:\t10\nSN\t0\tnumber of indels:\t3\n"
+    df = parseStats(output)
+    assert df.loc[df["type"] == "records", "count"].iloc[0] == 10
+    assert df.loc[df["type"] == "indels", "count"].iloc[0] == 3
+
+
+def test_count_vcf_rows(tmp_path: Path):
+    text = (
+        "##fileformat=VCFv4.2\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        "chr1\t1\t.\tA\tC\t.\tPASS\t.\n"
+        "chr1\t2\t.\tG\tT\t.\tPASS\t.\n"
+    )
+    vcf = tmp_path / "a.vcf"
+    vcf.write_text(text)
+    assert countVCFRows(str(vcf)) == 2
+
+    gz_path = tmp_path / "a.vcf.gz"
+    with gzip.open(gz_path, "wt") as f:
+        f.write(text)
+    assert countVCFRows(str(gz_path)) == 2

--- a/tests/unit/test_bedintervaltree.py
+++ b/tests/unit/test_bedintervaltree.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("bx")
+
+from hap_py.tools.bedintervaltree import BedIntervalTree
+
+
+def test_intersect_and_counts(tmp_path: Path) -> None:
+    bed = tmp_path / "ints.bed"
+    bed.write_text(
+        "chr1\t0\t10\nchr1\t20\t30\nchr2\t5\t15\n",
+        encoding="utf-8",
+    )
+    tree = BedIntervalTree()
+    tree.addFromBed(str(bed), label="test")
+
+    overlaps = tree.intersect("chr1", 5, 25)
+    assert len(overlaps) == 2
+    assert [iv.value for iv in overlaps] == ["test", "test"]
+
+    assert tree.countbases("chr1", 1, 31) == 20
+    assert tree.count(label="test") == 3

--- a/tests/unit/test_fastasize.py
+++ b/tests/unit/test_fastasize.py
@@ -1,6 +1,10 @@
 import pytest
 
-from hap_py.tools.fastasize import calculateLength
+from hap_py.tools.fastasize import (
+    calculateLength,
+    fastaNonNContigLengths,
+    fastaSampleRegions,
+)
 
 
 @pytest.mark.unit
@@ -9,3 +13,19 @@ def test_fastasize_calculation():
     locations = "chrMT chrY:1-10"
     contigs = "{'chrY': 59373566, 'chrM': 16571}"
     assert calculateLength(contigs, locations) == 10
+
+
+@pytest.mark.unit
+def test_fasta_non_n_lengths():
+    lengths = fastaNonNContigLengths("tests/data/common/test.fa")
+    assert lengths["chrQ"] == 8
+    assert lengths["all"] == 8
+
+
+def test_fasta_sample_regions(monkeypatch):
+    # Force deterministic random selection
+    monkeypatch.setattr("random.randint", lambda a, b: 0)
+    regions = fastaSampleRegions(
+        "tests/data/common/test.fa", n_regions=1, region_length=2
+    )
+    assert regions == ["chrQ:0-2"]

--- a/tests/unit/test_gvcf2bed.py
+++ b/tests/unit/test_gvcf2bed.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+
+import pysam
+
+from hap_py.haplo import gvcf2bed
+
+
+def create_vcf(path: Path) -> None:
+    header = pysam.VariantHeader()
+    header.add_meta("fileformat", "VCFv4.2")
+    header.contigs.add("chr1")
+    header.add_sample("SAMPLE")
+    header.formats.add("GT", number=1, type="String", description="Genotype")
+    header.filters.add("FAIL", None, None, "Fail filter")
+
+    with pysam.VariantFile(str(path), "w", header=header) as out:
+        rec1 = header.new_record(contig="chr1", start=0, stop=1, alleles=("A", "C"))
+        rec1.filter.add("PASS")
+        rec1.samples["SAMPLE"]["GT"] = (0, 1)
+        out.write(rec1)
+
+        rec2 = header.new_record(contig="chr1", start=10, stop=11, alleles=("G", "T"))
+        rec2.filter.add("FAIL")
+        rec2.samples["SAMPLE"]["GT"] = (0, 1)
+        out.write(rec2)
+
+
+def create_overlap_vcf(path: Path) -> None:
+    """Create a VCF with adjacent confident calls."""
+    header = pysam.VariantHeader()
+    header.add_meta("fileformat", "VCFv4.2")
+    header.contigs.add("chr1")
+    header.add_sample("SAMPLE")
+    header.formats.add("GT", number=1, type="String", description="Genotype")
+
+    with pysam.VariantFile(str(path), "w", header=header) as out:
+        r1 = header.new_record(contig="chr1", start=0, stop=1, alleles=("A", "C"))
+        r1.filter.add("PASS")
+        r1.samples["SAMPLE"]["GT"] = (0, 1)
+        out.write(r1)
+
+        r2 = header.new_record(contig="chr1", start=1, stop=2, alleles=("G", "T"))
+        r2.filter.add("PASS")
+        r2.samples["SAMPLE"]["GT"] = (0, 1)
+        out.write(r2)
+
+
+def create_uncertain_vcf(path: Path) -> None:
+    """VCF with non-PASS and missing genotype records."""
+    header = pysam.VariantHeader()
+    header.add_meta("fileformat", "VCFv4.2")
+    header.contigs.add("chr1")
+    header.add_sample("SAMPLE")
+    header.formats.add("GT", number=1, type="String", description="Genotype")
+    header.filters.add("LowQual", None, None, "Low quality")
+
+    with pysam.VariantFile(str(path), "w", header=header) as out:
+        fail_rec = header.new_record(contig="chr1", start=0, stop=1, alleles=("A", "C"))
+        fail_rec.filter.add("LowQual")
+        fail_rec.samples["SAMPLE"]["GT"] = (0, 1)
+        out.write(fail_rec)
+
+        nocall = header.new_record(contig="chr1", start=5, stop=6, alleles=("G", "T"))
+        nocall.filter.add("PASS")
+        nocall.samples["SAMPLE"]["GT"] = (None, None)
+        out.write(nocall)
+
+
+def test_gvcf2bed_basic(tmp_path: Path) -> None:
+    vcf = tmp_path / "test.vcf"
+    create_vcf(vcf)
+    ref = Path("tests/data/common/test.fa")
+    bed_path = gvcf2bed.gvcf2bed(str(vcf), str(ref), scratch_prefix=str(tmp_path))
+    with open(bed_path, encoding="utf-8") as fh:
+        lines = [line.strip() for line in fh.readlines()]
+    assert lines == ["chr1\t0\t1"]
+
+
+def test_gvcf2bed_regions_filter(tmp_path: Path) -> None:
+    vcf = tmp_path / "test.vcf"
+    create_vcf(vcf)
+    regions = tmp_path / "regions.bed"
+    regions.write_text("chr1\t5\t6\n")
+    ref = Path("tests/data/common/test.fa")
+    bed_path = gvcf2bed.gvcf2bed(
+        str(vcf), str(ref), regions=str(regions), scratch_prefix=str(tmp_path)
+    )
+    with open(bed_path, encoding="utf-8") as fh:
+        content = fh.read().strip()
+    assert content == ""
+
+
+def test_gvcf2bed_merge_adjacent(tmp_path: Path) -> None:
+    vcf = tmp_path / "merge.vcf"
+    create_overlap_vcf(vcf)
+    ref = Path("tests/data/common/test.fa")
+    bed_path = gvcf2bed.gvcf2bed(str(vcf), str(ref), scratch_prefix=str(tmp_path))
+    with open(bed_path, encoding="utf-8") as fh:
+        lines = [line.strip() for line in fh.readlines()]
+    assert lines == ["chr1\t0\t2"]
+
+
+def test_gvcf2bed_skip_uncertain(tmp_path: Path) -> None:
+    vcf = tmp_path / "uncertain.vcf"
+    create_uncertain_vcf(vcf)
+    ref = Path("tests/data/common/test.fa")
+    bed_path = gvcf2bed.gvcf2bed(str(vcf), str(ref), scratch_prefix=str(tmp_path))
+    with open(bed_path, encoding="utf-8") as fh:
+        content = fh.read().strip()
+    assert content == ""

--- a/tests/unit/test_multimerge_unit.py
+++ b/tests/unit/test_multimerge_unit.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+
+import pysam
+import pytest
+
+from hap_py.utils import multimerge
+
+
+def create_simple_vcf(path: Path, sample: str) -> None:
+    header = pysam.VariantHeader()
+    header.add_meta("fileformat", "VCFv4.2")
+    header.contigs.add("chr1")
+    header.add_sample(sample)
+    header.formats.add("GT", number=1, type="String", description="Genotype")
+
+    with pysam.VariantFile(str(path), "w", header=header) as out:
+        rec = header.new_record(contig="chr1", start=0, stop=1, alleles=("A", "C"))
+        rec.samples[sample]["GT"] = (0, 1)
+        out.write(rec)
+
+
+def create_alt_vcf(path: Path, sample: str, alt: str) -> None:
+    """Create VCF with a configurable ALT allele."""
+    header = pysam.VariantHeader()
+    header.add_meta("fileformat", "VCFv4.2")
+    header.contigs.add("chr1")
+    header.add_sample(sample)
+    header.formats.add("GT", number=1, type="String", description="Genotype")
+
+    with pysam.VariantFile(str(path), "w", header=header) as out:
+        rec = header.new_record(contig="chr1", start=0, stop=1, alleles=("A", alt))
+        rec.samples[sample]["GT"] = (0, 1)
+        out.write(rec)
+
+
+def test_parse_args() -> None:
+    ns = multimerge._parse_args(
+        [
+            "a.vcf:S1",
+            "b.vcf:S2",
+            "-o",
+            "out.vcf",
+            "-r",
+            "ref.fa",
+        ]
+    )
+    assert ns.inputs == ["a.vcf:S1", "b.vcf:S2"]
+    assert ns.output == "out.vcf"
+    assert ns.reference == "ref.fa"
+
+
+def test_parse_args_missing_output() -> None:
+    with pytest.raises(SystemExit):
+        multimerge._parse_args(["a.vcf:S1", "-r", "ref.fa"])
+
+
+def test_merge_records(tmp_path: Path) -> None:
+    v1 = tmp_path / "a.vcf"
+    v2 = tmp_path / "b.vcf"
+    create_simple_vcf(v1, "S1")
+    create_simple_vcf(v2, "S2")
+    out_vcf = tmp_path / "merged.vcf"
+
+    multimerge._merge_records([(v1, "S1"), (v2, "S2")], out_vcf, tmp_path / "ref.fa")
+
+    with pysam.VariantFile(str(out_vcf)) as vf:
+        records = list(vf.fetch())
+        assert len(records) == 1
+        assert list(vf.header.samples) == ["S1", "S2"]
+        gt1 = records[0].samples["S1"]["GT"]
+        gt2 = records[0].samples["S2"]["GT"]
+        assert gt1 == (0, 1) and gt2 == (0, 1)
+
+
+def test_merge_records_union_alt(tmp_path: Path) -> None:
+    v1 = tmp_path / "a.vcf"
+    v2 = tmp_path / "b.vcf"
+    create_alt_vcf(v1, "S1", "T")
+    create_alt_vcf(v2, "S2", "G")
+    out_vcf = tmp_path / "merged.vcf"
+
+    multimerge._merge_records([(v1, "S1"), (v2, "S2")], out_vcf, tmp_path / "ref.fa")
+
+    with pysam.VariantFile(str(out_vcf)) as vf:
+        record = next(vf.fetch())
+        assert set(record.alts) == {"T", "G"}
+
+
+def test_main(tmp_path: Path) -> None:
+    v1 = tmp_path / "a.vcf"
+    v2 = tmp_path / "b.vcf"
+    create_simple_vcf(v1, "S1")
+    create_simple_vcf(v2, "S2")
+    out_vcf = tmp_path / "merged.vcf"
+    rc = multimerge.main(
+        [
+            f"{v1}:S1",
+            f"{v2}:S2",
+            "-o",
+            str(out_vcf),
+            "-r",
+            str(tmp_path / "ref.fa"),
+        ]
+    )
+    assert rc == 0
+    assert out_vcf.exists()
+
+
+def test_main_default_samples(tmp_path: Path) -> None:
+    v1 = tmp_path / "sample1.vcf"
+    v2 = tmp_path / "sample2.vcf"
+    create_simple_vcf(v1, "S1")
+    create_simple_vcf(v2, "S2")
+    out_vcf = tmp_path / "merged.vcf"
+    rc = multimerge.main(
+        [
+            str(v1),
+            str(v2),
+            "-o",
+            str(out_vcf),
+            "-r",
+            str(tmp_path / "ref.fa"),
+        ]
+    )
+    assert rc == 0
+    with pysam.VariantFile(str(out_vcf)) as vf:
+        assert list(vf.header.samples) == ["S1", "sample1", "sample2"]

--- a/tests/unit/test_python_preprocess.py
+++ b/tests/unit/test_python_preprocess.py
@@ -18,8 +18,7 @@ from hap_py.haplo.python_preprocess import DecomposeLevel, PreprocessEngine
 @pytest.fixture
 def reference_path():
     """Path to a small reference FASTA file for testing."""
-    repo_root = Path(__file__).resolve().parent.parent.parent
-    path = repo_root / "example" / "example.fa"
+    path = Path("tests/data/common/test.fa")
     assert path.exists(), f"Reference FASTA not found at {path}"
     # Ensure the .fai index exists or can be created by pysam
     if not (path.with_suffix(path.suffix + ".fai")).exists():
@@ -35,10 +34,9 @@ def reference_path():
 
 
 @pytest.fixture
-def example_vcf_path():
+def example_vcf_path(example_dir):
     """Path to an example VCF file for testing."""
-    repo_root = Path(__file__).resolve().parent.parent.parent
-    path = repo_root / "example" / "example.vcf.gz"
+    path = example_dir / "example.vcf.gz"
     assert path.exists(), f"Example VCF not found at {path}"
     # Ensure the .tbi index exists or can be created by pysam
     if not (path.with_suffix(path.suffix + ".tbi")).exists():


### PR DESCRIPTION
## Summary
- add new unit tests for bcftools and bedintervaltree utilities
- test FASTA helpers for non-N lengths and region sampling
- update CI workflows to run on dev-codex branch
- document coverage plan expansion in AGENTS.md
- note code improvement areas in bcftools and bedintervaltree

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/python-ci.yml AGENTS.md src/hap_py/tools/bcftools.py src/hap_py/tools/bedintervaltree.py tests/unit/test_fastasize.py tests/unit/test_bcftools.py tests/unit/test_bedintervaltree.py`
- `pytest tests/unit -v`

------
https://chatgpt.com/codex/tasks/task_e_684c908b0228832cb9414eb4c9900907