### PR TITLE
Add documentation site and update docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ som.py truth.vcf query.vcf -f confident.bed -o output_prefix -r reference.fa
 
 More information can be found below in the [usage section](#usage).
 
+Additional documentation, including an architecture overview, is available in
+the `docs/` directory and can be built locally using **MkDocs**.
+
 ## Contents
 
 * [Motivation](#motivation)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,41 @@
+# Package Architecture
+
+```dot
+// Graphviz diagram showing high level components
+// Run `dot -Tpng architecture.md -o architecture.png` to render
+
+digraph architecture {
+    rankdir=LR;
+    node [shape=box, style=filled, fillcolor=lightgray];
+    subgraph cluster_cli {
+        label="Command line tools";
+        hap[label="hap.py"];
+        pre[label="pre.py"];
+        qfy[label="qfy.py"];
+    }
+    subgraph cluster_haplo {
+        label="hap_py.haplo";
+        preprocess[label="python_preprocess"];
+        quantify[label="python_quantify"];
+        cmp[label="python_hapcmp"];
+        vcfcheck[label="python_vcfcheck"];
+        vcfeval[label="vcfeval"];
+    }
+    tools[label="hap_py.tools"];
+    utils[label="hap_py.utils"];
+
+    hap -> preprocess;
+    hap -> cmp;
+    hap -> vcfeval;
+    pre -> preprocess;
+    qfy -> quantify;
+
+    preprocess -> tools;
+    quantify -> tools;
+    cmp -> tools;
+    vcfeval -> tools;
+    vcfeval -> utils;
+}
+```
+
+This diagram illustrates how the top-level command line interfaces rely on the core modules under `hap_py.haplo`, which in turn use helper functions in `hap_py.tools` and `hap_py.utils`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# Haplotype Comparison Tools (hap.py)
+
+Welcome to the hap.py documentation site. This site provides an overview of the package along with links to detailed guides and API documentation.
+
+- [User Manual](../doc/happy.md)
+- [Quantify Module](../doc/quantify.md)
+- [Python 3 Migration Guide](../doc/python3_migration.md)
+- [Architecture](architecture.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: hap.py
+nav:
+  - Home: docs/index.md
+  - Architecture: docs/architecture.md
+  - User Manual: doc/happy.md
+  - Quantify Module: doc/quantify.md

--- a/src/hap_py/haplo/python_quantify.py
+++ b/src/hap_py/haplo/python_quantify.py
@@ -64,20 +64,30 @@ class QuantifyEngine:
         roc_bootstrap_samples: int = 1000,  # Phase 2: Bootstrap samples for confidence intervals
         quality_stratification: bool = True,  # Phase 2: Enable quality-based stratification
     ):
-        """
-        Initialize the quantify engine.
+        """Initialize the quantification engine.
 
-        Args:
-            truth_vcf: Path to truth VCF file
-            query_vcf: Path to query/test VCF file
-            reference: Path to reference FASTA file (optional)
-            regions: BED file with regions to quantify (optional)
-            apply_filters: Whether to apply filters from VCF
-            output_vtc: Whether to output variant truth categories
-            quantify_method: Quantification method - 'xcmp' or 'ga4gh'
-            enable_roc_analysis: Enable Phase 2 ROC analysis with confidence intervals
-            roc_bootstrap_samples: Number of bootstrap samples for confidence intervals
-            quality_stratification: Enable quality score-based stratification
+        Parameters
+        ----------
+        truth_vcf : str
+            Path to the truth VCF file.
+        query_vcf : str
+            Path to the query VCF produced by a variant caller.
+        reference : str, optional
+            Reference FASTA used for context (``None`` for no reference).
+        regions : str, optional
+            BED file restricting analysis to specific regions.
+        apply_filters : bool, default ``False``
+            Skip records that have failing FILTER flags.
+        output_vtc : bool, default ``False``
+            Write variant truth categories to an output VCF.
+        quantify_method : str, default ``"xcmp"``
+            Quantification strategy to use (``"xcmp"`` or ``"ga4gh"``).
+        enable_roc_analysis : bool, default ``True``
+            Generate ROC metrics as part of the analysis.
+        roc_bootstrap_samples : int, default ``1000``
+            Number of bootstrap samples used when estimating confidence intervals.
+        quality_stratification : bool, default ``True``
+            Produce stratifications based on variant quality.
         """
         self.truth_vcf = truth_vcf
         self.query_vcf = query_vcf

--- a/src/hap_py/tools/__init__.py
+++ b/src/hap_py/tools/__init__.py
@@ -80,7 +80,14 @@ GA4GH_TOOLS = ["bgzip", "tabix", "rtg"]
 
 
 def check_dependencies() -> dict:
-    """Return a mapping of external tools and whether they are available."""
+    """Check availability of bundled external tools.
+
+    Returns
+    -------
+    dict
+        Mapping of tool names to a boolean indicating if the executable can be
+        located.
+    """
     results = {}
     for tool in GA4GH_TOOLS:
         if tool == "rtg":

--- a/src/hap_py/tools/bcftools.py
+++ b/src/hap_py/tools/bcftools.py
@@ -29,16 +29,22 @@ scriptDir = os.path.abspath(os.path.dirname(__file__))
 
 
 def runShellCommand(*args: str) -> CommandOutput:
-    """Run a shell command (e.g. bcf tools), and return output
+    """Execute a command line program and capture its output.
 
-    Args:
-        *args: Command arguments
+    Parameters
+    ----------
+    *args : str
+        Individual command line arguments forming the command to run.
 
-    Returns:
-        Tuple of (stdout, stderr, return_code)
+    Returns
+    -------
+    Tuple[str, str, int]
+        Standard output, standard error and the exit code from the command.
 
-    Raises:
-        Exception: If command execution fails with non-zero return code
+    Raises
+    ------
+    Exception
+        If the command exits with a non-zero return code.
     """
     qargs = []
     for a in args:


### PR DESCRIPTION
## Summary
- document project architecture using a Graphviz diagram
- add simple MkDocs configuration and documentation index
- reference docs site from README
- expand QuantifyEngine and bcftools helpers docstrings

## Testing
- `pre-commit run --files README.md src/hap_py/haplo/python_quantify.py src/hap_py/tools/__init__.py src/hap_py/tools/bcftools.py mkdocs.yml docs/index.md docs/architecture.md`
- `pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6e1a8e64832c900c007dfa03b8a0